### PR TITLE
Automatically label new tickets

### DIFF
--- a/.github/NEW_TICKET.yml
+++ b/.github/NEW_TICKET.yml
@@ -1,0 +1,21 @@
+name: Label issues
+on:
+  issues:
+    types:
+      - reopened
+      - opened
+jobs:
+  label_issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ["needs-response"]
+            })


### PR DESCRIPTION
Add `needs-response` automatically to all new tickets.