### PR TITLE
add optional collab id for schema gen

### DIFF
--- a/c3r-cli/src/main/java/com/amazonaws/c3r/cli/EncryptMode.java
+++ b/c3r-cli/src/main/java/com/amazonaws/c3r/cli/EncryptMode.java
@@ -29,7 +29,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.Callable;
-import java.util.function.Function;
 
 import static com.amazonaws.c3r.cli.Main.generateCommandLine;
 
@@ -200,19 +199,6 @@ public class EncryptMode implements Callable<Integer> {
     public ClientSettings getClientSettings() {
         final ClientSettings settings = Objects.requireNonNullElseGet(cleanRoomsDao, CleanRoomsDao::new)
                 .getCollaborationDataEncryptionMetadata(requiredArgs.getId().toString());
-
-        final Function<Boolean, String> boolToYesNo = (b) -> b ? "yes" : "no";
-
-        log.debug("Cryptographic computing parameters found for collaboration {}:", requiredArgs.getId());
-        log.debug("  * Allow cleartext columns = {}",
-                boolToYesNo.apply(settings.isAllowCleartext()));
-        log.debug("  * Allow duplicates = {}",
-                boolToYesNo.apply(settings.isAllowDuplicates()));
-        log.debug("  * Allow JOIN of columns with different names = {}",
-                boolToYesNo.apply(settings.isAllowJoinsOnColumnsWithDifferentNames()));
-        log.debug("  * Preserve NULL values = {}",
-                boolToYesNo.apply(settings.isPreserveNulls()));
-
         return settings;
     }
 

--- a/c3r-cli/src/main/java/com/amazonaws/c3r/cli/SchemaMode.java
+++ b/c3r-cli/src/main/java/com/amazonaws/c3r/cli/SchemaMode.java
@@ -3,6 +3,8 @@
 
 package com.amazonaws.c3r.cli;
 
+import com.amazonaws.c3r.cleanrooms.CleanRoomsDao;
+import com.amazonaws.c3r.config.ClientSettings;
 import com.amazonaws.c3r.exception.C3rIllegalArgumentException;
 import com.amazonaws.c3r.io.FileFormat;
 import com.amazonaws.c3r.io.schema.CsvSchemaGenerator;
@@ -14,6 +16,7 @@ import picocli.CommandLine;
 import java.io.File;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.concurrent.Callable;
 
 import static com.amazonaws.c3r.cli.Main.generateCommandLine;
@@ -89,6 +92,14 @@ public class SchemaMode implements Callable<Integer> {
     @Getter
     static class OptionalArgs {
         /**
+         * For description see {@link CliDescriptions#ID_DESCRIPTION}.
+         */
+        @CommandLine.Option(names = {"--id"},
+                description = CliDescriptions.ID_DESCRIPTION,
+                paramLabel = "<value>")
+        private UUID id = null;
+
+        /**
          * If this input file has headers.
          *
          * <p>
@@ -136,23 +147,60 @@ public class SchemaMode implements Callable<Integer> {
     @CommandLine.ArgGroup(validate = false, heading = "%nOptional parameters:%n")
     private OptionalArgs optionalArgs = new OptionalArgs();
 
+    /** DAO for interacting with AWS Clean Rooms. */
+    private CleanRoomsDao cleanRoomsDao;
+
     /**
-     * Return a CLI instance for schema generation.
+     * Return a CLI instance for schema generation with no specified AWS Clean Rooms collaboration.
      *
      * <p>
      * Note: {@link #getApp} is the intended method for manually creating this class
      * with the appropriate CLI settings.
      */
     SchemaMode() {
+        this.cleanRoomsDao = null;
     }
 
     /**
-     * Get the schema mode command line application with standard CLI settings.
+     * Return a CLI instance for schema generation configured for a particular AWS Clean Rooms collaboration.
      *
-     * @return CommandLine interface for `schema` mode.
+     * <p>
+     * Note: {@link #getApp} is the intended method for manually creating this class
+     * with the appropriate CLI settings.
+     *
+     * @param cleanRoomsDao Object containing information on the cryptographic settings for the collaboration
+     *                      if provided, else {@code null}.
      */
-    public static CommandLine getApp() {
-        return generateCommandLine(new SchemaMode());
+    SchemaMode(final CleanRoomsDao cleanRoomsDao) {
+        this.cleanRoomsDao = cleanRoomsDao;
+    }
+
+    /**
+     * Get the schema mode command line application with a custom CleanRoomsDao.
+     *
+     * @param cleanRoomsDao AWS Clean Rooms data access object to use for schema mode.
+     * @return CommandLine interface for `schema` with customized AWS Clean Rooms access.
+     */
+    static CommandLine getApp(final CleanRoomsDao cleanRoomsDao) {
+        return generateCommandLine(new SchemaMode(cleanRoomsDao));
+    }
+
+    /**
+     * Get the settings from AWS Clean Rooms for this collaboration.
+     *
+     * @return Cryptographic computing rules for collaboration, else {@code null} if not applicable.
+     */
+    public ClientSettings getClientSettings() {
+        if (optionalArgs.id == null) {
+            return null;
+        }
+        final ClientSettings settings;
+        if (cleanRoomsDao == null) {
+            settings = new CleanRoomsDao().getCollaborationDataEncryptionMetadata(optionalArgs.id.toString());
+        } else {
+            settings = cleanRoomsDao.getCollaborationDataEncryptionMetadata(optionalArgs.id.toString());
+        }
+        return settings;
     }
 
     /**
@@ -194,6 +242,7 @@ public class SchemaMode implements Callable<Integer> {
                             .hasHeaders(optionalArgs.hasHeaders)
                             .targetJsonFile(outFile)
                             .overwrite(optionalArgs.overwrite)
+                            .clientSettings(getClientSettings())
                             .build();
                     csvSchemaGenerator.generateSchema(subMode);
                     break;
@@ -205,6 +254,7 @@ public class SchemaMode implements Callable<Integer> {
                             .inputParquetFile(requiredArgs.getInput())
                             .targetJsonFile(outFile)
                             .overwrite(optionalArgs.overwrite)
+                            .clientSettings(getClientSettings())
                             .build();
                     parquetSchemaGenerator.generateSchema(subMode);
                     break;

--- a/c3r-cli/src/main/java/com/amazonaws/c3r/io/schema/CsvSchemaGenerator.java
+++ b/c3r-cli/src/main/java/com/amazonaws/c3r/io/schema/CsvSchemaGenerator.java
@@ -3,6 +3,7 @@
 
 package com.amazonaws.c3r.io.schema;
 
+import com.amazonaws.c3r.config.ClientSettings;
 import com.amazonaws.c3r.data.CsvValue;
 import com.amazonaws.c3r.io.CsvRowReader;
 import com.amazonaws.c3r.utils.FileUtil;
@@ -42,13 +43,15 @@ public final class CsvSchemaGenerator extends SchemaGenerator {
      * @param targetJsonFile Where to save the schema
      * @param overwrite      If the {@code targetJsonFile} should be overwritten if it exists
      * @param hasHeaders     Does the first source row contain column headers?
+     * @param clientSettings Collaboration's client settings if provided, else {@code null}
      */
     @Builder
     private CsvSchemaGenerator(@NonNull final String inputCsvFile,
                                @NonNull final String targetJsonFile,
                                @NonNull final Boolean overwrite,
-                               @NonNull final Boolean hasHeaders) {
-        super(inputCsvFile, targetJsonFile, overwrite);
+                               @NonNull final Boolean hasHeaders,
+                               final ClientSettings clientSettings) {
+        super(inputCsvFile, targetJsonFile, overwrite, clientSettings);
         this.inputCsvFile = inputCsvFile;
         this.targetJsonFile = targetJsonFile;
         FileUtil.initFileIfNotExists(targetJsonFile);

--- a/c3r-cli/src/main/java/com/amazonaws/c3r/io/schema/ParquetSchemaGenerator.java
+++ b/c3r-cli/src/main/java/com/amazonaws/c3r/io/schema/ParquetSchemaGenerator.java
@@ -3,6 +3,7 @@
 
 package com.amazonaws.c3r.io.schema;
 
+import com.amazonaws.c3r.config.ClientSettings;
 import com.amazonaws.c3r.io.ParquetRowReader;
 import com.amazonaws.c3r.utils.FileUtil;
 import lombok.Builder;
@@ -19,12 +20,14 @@ public final class ParquetSchemaGenerator extends SchemaGenerator {
      * @param inputParquetFile Parquet file to read header information from
      * @param targetJsonFile   Where to save the schema
      * @param overwrite        Whether the {@code targetJsonFile} should be overwritten (if it exists)
+     * @param clientSettings   Collaboration's client settings if provided, else {@code null}
      */
     @Builder
     private ParquetSchemaGenerator(@NonNull final String inputParquetFile,
                                    @NonNull final String targetJsonFile,
-                                   @NonNull final Boolean overwrite) {
-        super(inputParquetFile, targetJsonFile, overwrite);
+                                   @NonNull final Boolean overwrite,
+                                   final ClientSettings clientSettings) {
+        super(inputParquetFile, targetJsonFile, overwrite, clientSettings);
         FileUtil.verifyReadableFile(inputParquetFile);
         final var reader = new ParquetRowReader(inputParquetFile);
         sourceHeaders = reader.getHeaders();

--- a/c3r-cli/src/main/java/com/amazonaws/c3r/io/schema/SchemaGenerator.java
+++ b/c3r-cli/src/main/java/com/amazonaws/c3r/io/schema/SchemaGenerator.java
@@ -4,6 +4,7 @@
 package com.amazonaws.c3r.io.schema;
 
 import com.amazonaws.c3r.cli.SchemaMode;
+import com.amazonaws.c3r.config.ClientSettings;
 import com.amazonaws.c3r.config.ColumnHeader;
 import com.amazonaws.c3r.data.ClientDataType;
 import com.amazonaws.c3r.exception.C3rIllegalArgumentException;
@@ -43,17 +44,27 @@ public abstract class SchemaGenerator {
     private final String targetJsonFile;
 
     /**
+     * Clean room cryptographic settings.
+     */
+    private final ClientSettings clientSettings;
+
+    /**
      * Setup common schema generator component.
      *
      * @param inputFile      Input data file for processing
      * @param targetJsonFile Schema file mapping input to output file data
      * @param overwrite      Whether to overwrite the output file if it already exists
+     * @param clientSettings       Collaboration settings if available, else {@code null}
      */
-    protected SchemaGenerator(@NonNull final String inputFile, @NonNull final String targetJsonFile, @NonNull final Boolean overwrite) {
+    protected SchemaGenerator(@NonNull final String inputFile,
+                              @NonNull final String targetJsonFile,
+                              @NonNull final Boolean overwrite,
+                              final ClientSettings clientSettings) {
         this.inputFile = inputFile;
         this.targetJsonFile = targetJsonFile;
         validate(overwrite);
         FileUtil.initFileIfNotExists(targetJsonFile);
+        this.clientSettings = clientSettings;
     }
 
     /**
@@ -84,6 +95,7 @@ public abstract class SchemaGenerator {
                     .targetJsonFile(targetJsonFile)
                     .consoleInput(new BufferedReader(new InputStreamReader(System.in, StandardCharsets.UTF_8)))
                     .consoleOutput(System.out)
+                    .clientSettings(clientSettings)
                     .build()
                     .run();
         } else if (subMode.isTemplateMode()) {
@@ -91,6 +103,7 @@ public abstract class SchemaGenerator {
                     .sourceHeaders(getSourceHeaders())
                     .sourceColumnTypes(getSourceColumnTypes())
                     .targetJsonFile(targetJsonFile)
+                    .clientSettings(clientSettings)
                     .build()
                     .run();
         } else {

--- a/c3r-cli/src/main/java/com/amazonaws/c3r/io/schema/SchemaGeneratorUtils.java
+++ b/c3r-cli/src/main/java/com/amazonaws/c3r/io/schema/SchemaGeneratorUtils.java
@@ -44,4 +44,21 @@ public final class SchemaGeneratorUtils {
                 "         used for cryptographic computing. Any target column(s) generated\n" +
                 "         from this column will be cleartext.";
     }
+
+    /**
+     * Returns a user-facing message stating the specified column cannot be encrypted in any way AND is being skipped.
+     *
+     * @param columnHeader The column header (if one exists)
+     * @param columnIndex  The column's 0-based index
+     * @return A warning string user facing I/O
+     */
+    public static String unsupportedTypeSkippingColumnWarning(final ColumnHeader columnHeader, final int columnIndex) {
+        final String columnName = columnReference(columnHeader, columnIndex);
+
+        final var sb = new StringBuilder();
+        sb.append("WARNING: " + columnName + " contains non-string data and cannot be\n");
+        sb.append("         used for cryptographic computing. This column is being skipped\n");
+        sb.append("         because the collaboration does not permit cleartext columns.");
+        return sb.toString();
+    }
 }

--- a/c3r-cli/src/main/java/com/amazonaws/c3r/io/schema/TemplateSchemaGenerator.java
+++ b/c3r-cli/src/main/java/com/amazonaws/c3r/io/schema/TemplateSchemaGenerator.java
@@ -3,7 +3,9 @@
 
 package com.amazonaws.c3r.io.schema;
 
+import com.amazonaws.c3r.config.ClientSettings;
 import com.amazonaws.c3r.config.ColumnHeader;
+import com.amazonaws.c3r.config.ColumnType;
 import com.amazonaws.c3r.data.ClientDataType;
 import com.amazonaws.c3r.exception.C3rIllegalArgumentException;
 import com.amazonaws.c3r.exception.C3rRuntimeException;
@@ -20,7 +22,9 @@ import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Used to create a simple schema without user input. Creates a one-to-one mapping in the output JSON file which the user can then edit to
@@ -28,10 +32,25 @@ import java.util.List;
  */
 @Slf4j
 public final class TemplateSchemaGenerator {
+
     /**
      * String for user-facing messaging showing column type options.
      */
-    private static final String COLUMN_TYPE_OPTIONS = "[cleartext|sealed|fingerprint]";
+    private static final String ALL_COLUMN_TYPES = "[" +
+            Arrays.stream(ColumnType.values())
+                    .map(ColumnType::toString)
+                    .collect(Collectors.joining("|")) +
+            "]";
+
+    /**
+     * String for user-facing messaging showing column type options.
+     */
+    private static final String ALL_COLUMN_TYPES_SANS_CLEARTEXT = "[" +
+            Arrays.stream(ColumnType.values())
+                    .filter(c -> c != ColumnType.CLEARTEXT)
+                    .map(ColumnType::toString)
+                    .collect(Collectors.joining("|")) +
+            "]";
 
     /**
      * The contents to be printed for each pad in the output, along with instructions on how to use it.
@@ -71,19 +90,31 @@ public final class TemplateSchemaGenerator {
     private final String targetJsonFile;
 
     /**
+     * Options for column types based on ClientSettings (if provided).
+     */
+    private final String columnTypeOptions;
+
+    /**
+     * Whether this schema can have cleartext columns.
+     */
+    private final boolean allowCleartextColumns;
+
+    /**
      * Initializes the automated schema generator.
      *
      * @param sourceHeaders     List of column names in the input file
      * @param sourceColumnTypes Source column types (in the order they appear in the input file)
      * @param targetJsonFile    Where to write the schema
      * @param consoleOutput     Connection to output stream (i.e., output for user)
+     * @param clientSettings    Collaboration's client settings if provided, else {@code null}
      * @throws C3rIllegalArgumentException If input sizes are inconsistent
      */
     @Builder
     private TemplateSchemaGenerator(final List<ColumnHeader> sourceHeaders,
                                     @NonNull final List<ClientDataType> sourceColumnTypes,
                                     @NonNull final String targetJsonFile,
-                                    final PrintStream consoleOutput) {
+                                    final PrintStream consoleOutput,
+                                    final ClientSettings clientSettings) {
         if (sourceHeaders != null && sourceHeaders.size() != sourceColumnTypes.size()) {
             throw new C3rIllegalArgumentException("Template schema generator given "
                     + sourceHeaders.size() + " headers and " + sourceColumnTypes.size() + " column data types.");
@@ -94,6 +125,12 @@ public final class TemplateSchemaGenerator {
         this.targetJsonFile = targetJsonFile;
         this.consoleOutput = (consoleOutput == null) ? new PrintStream(System.out, true, StandardCharsets.UTF_8)
                 : consoleOutput;
+        allowCleartextColumns = clientSettings == null || clientSettings.isAllowCleartext();
+        if (allowCleartextColumns) {
+            columnTypeOptions = ALL_COLUMN_TYPES;
+        } else {
+            columnTypeOptions = ALL_COLUMN_TYPES_SANS_CLEARTEXT;
+        }
     }
 
     /**
@@ -109,11 +146,14 @@ public final class TemplateSchemaGenerator {
             entry.addProperty("sourceHeader", header.toString());
             entry.addProperty("targetHeader", header.toString());
             if (sourceColumnTypes.get(i).supportsCryptographicComputing()) {
-                entry.addProperty("type", COLUMN_TYPE_OPTIONS);
+                entry.addProperty("type", columnTypeOptions);
                 entry.add("pad", EXAMPLE_PAD);
-            } else {
+            } else if (allowCleartextColumns) {
                 consoleOutput.println(SchemaGeneratorUtils.unsupportedTypeWarning(header, i));
-                entry.addProperty("type", "cleartext");
+                entry.addProperty("type", ColumnType.CLEARTEXT.toString());
+            } else {
+                consoleOutput.println(SchemaGeneratorUtils.unsupportedTypeSkippingColumnWarning(header, i));
+                continue;
             }
             columnSchemaArray.add(entry);
         }
@@ -128,16 +168,23 @@ public final class TemplateSchemaGenerator {
     private JsonArray generateTemplateColumnSchemasFromColumnCount() {
         final var columnSchemaArray = new JsonArray(sourceColumnCount);
         for (int i = 0; i < sourceColumnCount; i++) {
-            final var entry = new JsonObject();
-            entry.addProperty("targetHeader", ColumnHeader.getColumnHeaderFromIndex(i).toString());
-            if (sourceColumnTypes.get(i).equals(ClientDataType.STRING)) {
-                entry.addProperty("type", COLUMN_TYPE_OPTIONS);
-                entry.add("pad", EXAMPLE_PAD);
-            } else {
-                entry.addProperty("type", "cleartext");
-            }
+            // Array template entry will go in
             final var entryArray = new JsonArray(1);
-            entryArray.add(entry);
+            // template entry
+            final var templateEntry = new JsonObject();
+            templateEntry.addProperty("targetHeader", ColumnHeader.getColumnHeaderFromIndex(i).toString());
+            if (sourceColumnTypes.get(i).supportsCryptographicComputing()) {
+                templateEntry.addProperty("type", columnTypeOptions);
+                templateEntry.add("pad", EXAMPLE_PAD);
+                entryArray.add(templateEntry);
+            } else if (allowCleartextColumns) {
+                templateEntry.addProperty("type", ColumnType.CLEARTEXT.toString());
+                entryArray.add(templateEntry);
+            } else {
+                // If the column type does not support cryptographic computing and cleartext columns are not allowed,
+                // then we do not add a template entry to the array, and we warn the user this column has been skipped.
+                consoleOutput.println(SchemaGeneratorUtils.unsupportedTypeSkippingColumnWarning(null, i));
+            }
             columnSchemaArray.add(entryArray);
         }
         return columnSchemaArray;

--- a/c3r-cli/src/test/java/com/amazonaws/c3r/cli/MainErrorMessageTest.java
+++ b/c3r-cli/src/test/java/com/amazonaws/c3r/cli/MainErrorMessageTest.java
@@ -79,7 +79,7 @@ public class MainErrorMessageTest {
 
     private void schemaAndCheckErrorMessagePresent(final SchemaCliConfigTestUtility args, final boolean enableStackTraces,
                                                    final String message) {
-        final CommandLine cmd = SchemaMode.getApp();
+        final CommandLine cmd = SchemaMode.getApp(null);
         runAndCheckErrorMessagePresent(cmd, args.toArrayWithoutMode(), enableStackTraces, message, C3rIllegalArgumentException.class);
     }
 

--- a/c3r-cli/src/test/java/com/amazonaws/c3r/cli/MainTest.java
+++ b/c3r-cli/src/test/java/com/amazonaws/c3r/cli/MainTest.java
@@ -13,8 +13,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import picocli.CommandLine;
 
-import java.io.BufferedInputStream;
-import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
@@ -115,7 +113,7 @@ public class MainTest {
     @Test
     public void marshalTest() throws IOException {
         encArgs.setInput("../samples/csv/data_sample_without_quotes.csv");
-        final File output = new File("data_sample.csv.out");
+        final File output = new File("data_sample_without_quotes.csv.out");
         encArgs.setOutput(output.getAbsolutePath());
 
         final long sourceLineCount;
@@ -291,38 +289,4 @@ public class MainTest {
         clientRoundTripTest(FileFormat.PARQUET);
     }
 
-    @Test
-    public void schemaTemplateTest() {
-        final String originalPath = "../samples/csv/data_sample_without_quotes.csv";
-        final String schemaPath = tempDir.resolve("data_sample.json").toString();
-
-        final var args = SchemaCliConfigTestUtility.builder().input(originalPath).output(schemaPath).subMode("--template").build();
-
-        final int exitCode = Main.getApp().execute(args.toArray());
-        assertEquals(0, exitCode);
-
-        assertTrue(new File(schemaPath).exists());
-        assertTrue(new File(schemaPath).length() > 0);
-    }
-
-    // Check that interactive schema command returns results
-    @Test
-    public void schemaInteractiveTest() {
-        final String originalPath = "../samples/csv/data_sample_without_quotes.csv";
-        final Path schemaPath = tempDir.resolve("schemaInteractive.json");
-
-        final var args = SchemaCliConfigTestUtility.builder().input(originalPath).output(schemaPath.toAbsolutePath().toString())
-                .subMode("--interactive").overwrite(true).build();
-
-        // user input which repeatedly says the source column in question should generate one cleartext column
-        // with the default name
-        final var userInput = new ByteArrayInputStream("1\ncleartext\n\n".repeat(100).getBytes(StandardCharsets.UTF_8));
-        System.setIn(new BufferedInputStream(userInput));
-
-        final int exitCode = Main.getApp().execute(args.toArray());
-        assertEquals(0, exitCode);
-
-        assertTrue(schemaPath.toFile().exists());
-        assertTrue(schemaPath.toFile().length() > 0);
-    }
 }

--- a/c3r-cli/src/test/java/com/amazonaws/c3r/cli/SchemaCliConfigTestUtility.java
+++ b/c3r-cli/src/test/java/com/amazonaws/c3r/cli/SchemaCliConfigTestUtility.java
@@ -67,6 +67,11 @@ public class SchemaCliConfigTestUtility {
     private boolean noHeaders = false;
 
     /**
+     * Collaboration ID.
+     */
+    private String collaborationId;
+
+    /**
      * Converts the specified command line parameters to a list.
      *
      * @return List of command line parameters
@@ -95,6 +100,9 @@ public class SchemaCliConfigTestUtility {
         }
         if (noHeaders) {
             args.add("--noHeaders");
+        }
+        if (collaborationId != null) {
+            args.add("--id=" + collaborationId);
         }
         return args;
     }

--- a/c3r-cli/src/test/java/com/amazonaws/c3r/cli/SchemaModeTest.java
+++ b/c3r-cli/src/test/java/com/amazonaws/c3r/cli/SchemaModeTest.java
@@ -3,10 +3,11 @@
 
 package com.amazonaws.c3r.cli;
 
+import com.amazonaws.c3r.cleanrooms.CleanRoomsDao;
+import com.amazonaws.c3r.config.ClientSettings;
 import com.amazonaws.c3r.config.ColumnType;
-import com.amazonaws.c3r.io.CsvRowReader;
+import com.amazonaws.c3r.utils.GeneralTestUtility;
 import com.amazonaws.c3r.utils.StringTestUtility;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -16,153 +17,135 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class SchemaModeTest {
     private static final int SAMPLE_DATA_COLUMN_COUNT = 9;
 
-    private static final String MATCH_ALL_COLUMN_TYPES = "[" + ColumnType.CLEARTEXT + "|" + ColumnType.SEALED + "|"
-            + ColumnType.FINGERPRINT + "]";
+    private static final String ALL_COLUMN_TYPES =
+            "[" + Arrays.stream(ColumnType.values())
+                    .map(ColumnType::toString)
+                    .collect(Collectors.joining("|")) + "]";
+
+    private static final String ALL_COLUMN_TYPES_SANS_CLEARTEXT =
+            "[" + Arrays.stream(ColumnType.values())
+                    .filter(c -> c != ColumnType.CLEARTEXT)
+                    .map(ColumnType::toString)
+                    .collect(Collectors.joining("|")) + "]";
 
     private Path schemaPath;
 
     @BeforeEach
     public void setup() throws IOException {
-        schemaPath = Files.createTempFile("data_sample", ".json");
+        final Path tempDir = Files.createTempDirectory("temp");
+        tempDir.toFile().deleteOnExit();
+        schemaPath = tempDir.resolve("schema.json");
         schemaPath.toFile().deleteOnExit();
     }
 
-    @AfterEach
-    public void teardown() throws IOException {
-        Files.delete(schemaPath);
-    }
-
-    @Test
-    public void schemaTemplateCsvTest() throws IOException {
-        final String originalPath = "../samples/csv/data_sample_without_quotes.csv";
-
+    // Generate a template without settings and shallowly check content contains expected entries
+    private void runTemplateGeneratorNoSettings(final String inputFile,
+                                                final boolean hasHeaderRow) throws IOException {
         final var args = SchemaCliConfigTestUtility.builder()
-                .input(originalPath)
+                .input(inputFile)
                 .output(schemaPath.toString())
                 .subMode("--template")
+                .noHeaders(!hasHeaderRow)
                 .overwrite(true)
                 .build();
 
-        final int exitCode = SchemaMode.getApp().execute(args.toArrayWithoutMode());
-
-        assertEquals(0, exitCode);
+        assertEquals(0, SchemaMode.getApp(null).execute(args.toArrayWithoutMode()));
 
         assertTrue(Files.exists(schemaPath));
         assertTrue(Files.size(schemaPath) > 0);
         final String contents = Files.readString(schemaPath);
-        assertTrue(contents.contains("\"headerRow\": true"));
-        assertEquals(SAMPLE_DATA_COLUMN_COUNT,
+        assertTrue(contents.contains("\"headerRow\": " + hasHeaderRow));
+        assertEquals(hasHeaderRow ? SAMPLE_DATA_COLUMN_COUNT : 0,
                 StringTestUtility.countMatches("sourceHeader", contents));
         assertEquals(SAMPLE_DATA_COLUMN_COUNT,
-                StringTestUtility.countMatches(MATCH_ALL_COLUMN_TYPES, contents));
+                StringTestUtility.countMatches(ALL_COLUMN_TYPES, contents));
     }
 
-    @Test
-    public void schemaTemplateCsvNoHeadersTest() throws IOException {
-        final String originalPath = "../samples/csv/data_sample_no_headers.csv";
-
+    // Generate a template with permissive settings and shallowly check content contains expected entries
+    private void runTemplateGeneratorPermissiveSettings(final String inputFile,
+                                                        final boolean hasHeaderRow) throws IOException {
         final var args = SchemaCliConfigTestUtility.builder()
-                .input(originalPath)
+                .input(inputFile)
                 .output(schemaPath.toString())
                 .subMode("--template")
+                .noHeaders(!hasHeaderRow)
                 .overwrite(true)
-                .noHeaders(true)
+                .collaborationId(GeneralTestUtility.EXAMPLE_SALT.toString())
                 .build();
+        final var cleanRoomsDao = mock(CleanRoomsDao.class);
+        when(cleanRoomsDao.getCollaborationDataEncryptionMetadata(any())).thenReturn(ClientSettings.lowAssuranceMode());
 
-        final int exitCode = SchemaMode.getApp().execute(args.toArrayWithoutMode());
-
-        assertEquals(0, exitCode);
+        assertEquals(0, SchemaMode.getApp(cleanRoomsDao).execute(args.toArrayWithoutMode()));
 
         assertTrue(Files.exists(schemaPath));
         assertTrue(Files.size(schemaPath) > 0);
         final String contents = Files.readString(schemaPath);
-        assertTrue(contents.contains("\"headerRow\": false"));
-        assertEquals(0,
+        assertTrue(contents.contains("\"headerRow\": " + hasHeaderRow));
+        assertEquals(hasHeaderRow ? SAMPLE_DATA_COLUMN_COUNT : 0,
                 StringTestUtility.countMatches("sourceHeader", contents));
         assertEquals(SAMPLE_DATA_COLUMN_COUNT,
-                StringTestUtility.countMatches(MATCH_ALL_COLUMN_TYPES, contents));
+                StringTestUtility.countMatches(ALL_COLUMN_TYPES, contents));
     }
 
-    @Test
-    public void schemaTemplateParquetTest() throws IOException {
-        final String originalPath = "../samples/parquet/data_sample.parquet";
-
+    // Generate a template with restrictive settings and shallowly check content contains expected entries
+    private void runTemplateGeneratorRestrictiveSettings(final String inputFile,
+                                                         final int expectedTargetColumnCount,
+                                                         final boolean hasHeaderRow) throws IOException {
         final var args = SchemaCliConfigTestUtility.builder()
-                .input(originalPath)
+                .input(inputFile)
                 .output(schemaPath.toString())
                 .subMode("--template")
+                .noHeaders(!hasHeaderRow)
                 .overwrite(true)
+                .collaborationId(GeneralTestUtility.EXAMPLE_SALT.toString())
                 .build();
+        final var cleanRoomsDao = mock(CleanRoomsDao.class);
+        when(cleanRoomsDao.getCollaborationDataEncryptionMetadata(any())).thenReturn(ClientSettings.highAssuranceMode());
 
-        final int exitCode = SchemaMode.getApp().execute(args.toArrayWithoutMode());
-
-        assertEquals(0, exitCode);
+        assertEquals(0, SchemaMode.getApp(cleanRoomsDao).execute(args.toArrayWithoutMode()));
 
         assertTrue(Files.exists(schemaPath));
         assertTrue(Files.size(schemaPath) > 0);
         final String contents = Files.readString(schemaPath);
-        assertTrue(contents.contains("\"headerRow\": true"));
-        assertEquals(SAMPLE_DATA_COLUMN_COUNT,
+        assertTrue(contents.contains("\"headerRow\": " + hasHeaderRow));
+        assertEquals(hasHeaderRow ? expectedTargetColumnCount : 0,
                 StringTestUtility.countMatches("sourceHeader", contents));
-        assertEquals(SAMPLE_DATA_COLUMN_COUNT,
-                StringTestUtility.countMatches(MATCH_ALL_COLUMN_TYPES, contents));
+        assertEquals(expectedTargetColumnCount,
+                StringTestUtility.countMatches("targetHeader", contents));
+        assertEquals(expectedTargetColumnCount,
+                StringTestUtility.countMatches(ALL_COLUMN_TYPES_SANS_CLEARTEXT, contents));
     }
 
-    // Check that interactive schema command returns results and shallowly check content contains expected entries
-    @Test
-    public void schemaInteractiveCsvTest() throws IOException {
-        final String originalPath = "../samples/csv/data_sample_without_quotes.csv";
-
+    // Run interactive schema gen without settings and check it returns results
+    // and shallowly check content contains expected entries
+    private void runInteractiveGeneratorNoSettings(final String inputFile,
+                                                   final boolean hasHeaderRow) throws IOException {
         final var args = SchemaCliConfigTestUtility.builder()
-                .input(originalPath)
-                .output(schemaPath.toAbsolutePath().toString())
+                .input(inputFile)
+                .output(schemaPath.toString())
                 .subMode("--interactive")
+                .noHeaders(!hasHeaderRow)
                 .overwrite(true)
                 .build();
-
+        // number greater than test file column counts (test will fail if too low, so no incorrectness risk in
+        // picking a number)
+        final int columnCountUpperBound = 100;
         // user input which repeatedly says the source column in question should generate one cleartext column
-        // with the default name
-        final var userInput = new ByteArrayInputStream("1\ncleartext\n\n".repeat(100).getBytes(StandardCharsets.UTF_8));
-        System.setIn(new BufferedInputStream(userInput));
-
-        final int exitCode = Main.getApp().execute(args.toArray());
-        assertEquals(0, exitCode);
-
-        assertTrue(schemaPath.toFile().exists());
-        assertTrue(schemaPath.toFile().length() > 0);
-        final String contents = Files.readString(schemaPath);
-        assertTrue(contents.contains("\"headerRow\": true"));
-        assertEquals(SAMPLE_DATA_COLUMN_COUNT,
-                StringTestUtility.countMatches("sourceHeader", contents));
-        assertEquals(SAMPLE_DATA_COLUMN_COUNT,
-                StringTestUtility.countMatches(ColumnType.CLEARTEXT.toString(), contents));
-    }
-
-    // Check that interactive schema command returns results and shallowly check content contains expected entries
-    @Test
-    public void schemaInteractiveCsvWithoutHeadersTest() throws IOException {
-        final String originalPath = "../samples/csv/data_sample_no_headers.csv";
-
-        final var args = SchemaCliConfigTestUtility.builder()
-                .input(originalPath)
-                .output(schemaPath.toAbsolutePath().toString())
-                .subMode("--interactive")
-                .noHeaders(true)
-                .overwrite(true)
-                .build();
-
-        // user input which repeatedly says the source column in question should generate one cleartext column
-        // with the default name
-        final int columnCount = CsvRowReader.getCsvColumnCount(originalPath, StandardCharsets.UTF_8);
+        // with a trivial name
         final StringBuilder inputBuilder = new StringBuilder();
-        for (int i = 0; i < columnCount; i++) {
+        for (int i = 0; i < columnCountUpperBound; i++) {
             // 1 target column
             inputBuilder.append("1\n");
             // target column type
@@ -170,20 +153,219 @@ public class SchemaModeTest {
             // target column name
             inputBuilder.append("column").append(i).append('\n');
         }
-
         final var userInput = new ByteArrayInputStream(inputBuilder.toString().getBytes(StandardCharsets.UTF_8));
         System.setIn(new BufferedInputStream(userInput));
 
-        final int exitCode = Main.getApp().execute(args.toArray());
-        assertEquals(0, exitCode);
+        assertEquals(0, Main.getApp().execute(args.toArray()));
 
         assertTrue(schemaPath.toFile().exists());
         assertTrue(schemaPath.toFile().length() > 0);
         final String contents = Files.readString(schemaPath);
-        assertTrue(contents.contains("\"headerRow\": false"));
-        assertEquals(0,
+        assertTrue(contents.contains("\"headerRow\": " + hasHeaderRow));
+        assertEquals(hasHeaderRow ? SAMPLE_DATA_COLUMN_COUNT : 0,
                 StringTestUtility.countMatches("sourceHeader", contents));
         assertEquals(SAMPLE_DATA_COLUMN_COUNT,
+                StringTestUtility.countMatches("\"" + ColumnType.CLEARTEXT + "\"", contents));
+    }
+
+    // Run interactive schema gen with permissive settings and check it returns results
+    // and shallowly check content contains expected entries
+
+    private void runInteractiveGeneratorPermissiveSettings(final String inputFile,
+                                                           final boolean hasHeaderRow) throws IOException {
+        final var args = SchemaCliConfigTestUtility.builder()
+                .input(inputFile)
+                .output(schemaPath.toString())
+                .subMode("--interactive")
+                .noHeaders(!hasHeaderRow)
+                .overwrite(true)
+                .collaborationId(GeneralTestUtility.EXAMPLE_SALT.toString())
+                .build();
+        // number greater than test file column counts (test will fail if too low, so no incorrectness risk in
+        // picking a number)
+        final int columnCountUpperBound = 100;
+        // user input which repeatedly says the source column in question should generate one cleartext column
+        // with a trivial name
+        final StringBuilder inputBuilder = new StringBuilder();
+        for (int i = 0; i < columnCountUpperBound; i++) {
+            // 1 target column
+            inputBuilder.append("1\n");
+            // target column type
+            inputBuilder.append("cleartext\n");
+            // target column name
+            inputBuilder.append("column").append(i).append('\n');
+        }
+        final var userInput = new ByteArrayInputStream(inputBuilder.toString().getBytes(StandardCharsets.UTF_8));
+        System.setIn(new BufferedInputStream(userInput));
+
+        final var cleanRoomsDao = mock(CleanRoomsDao.class);
+        when(cleanRoomsDao.getCollaborationDataEncryptionMetadata(any())).thenReturn(ClientSettings.lowAssuranceMode());
+
+        assertEquals(0, SchemaMode.getApp(cleanRoomsDao).execute(args.toArrayWithoutMode()));
+
+        assertTrue(schemaPath.toFile().exists());
+        assertTrue(schemaPath.toFile().length() > 0);
+        final String contents = Files.readString(schemaPath);
+        assertTrue(contents.contains("\"headerRow\": " + hasHeaderRow));
+        assertEquals(hasHeaderRow ? SAMPLE_DATA_COLUMN_COUNT : 0,
+                StringTestUtility.countMatches("sourceHeader", contents));
+        assertEquals(SAMPLE_DATA_COLUMN_COUNT,
+                StringTestUtility.countMatches("\"" + ColumnType.CLEARTEXT + "\"", contents));
+    }
+
+    // Run interactive schema gen with restrictive settings and check it returns results
+    // and shallowly check content contains expected entries=
+    private void runInteractiveGeneratorRestrictiveSettings(final String inputFile,
+                                                            final int expectedTargetColumnCount,
+                                                            final boolean hasHeaderRow) throws IOException {
+        final var args = SchemaCliConfigTestUtility.builder()
+                .input(inputFile)
+                .output(schemaPath.toString())
+                .subMode("--interactive")
+                .noHeaders(!hasHeaderRow)
+                .overwrite(true)
+                .collaborationId(GeneralTestUtility.EXAMPLE_SALT.toString())
+                .build();
+        // number greater than test file column counts (test will fail if too low, so no incorrectness risk in
+        // picking a number)
+        final int columnCountUpperBound = 100;
+        // user input which repeatedly says the source column in question should generate one cleartext column
+        // with a trivial name
+        final StringBuilder inputBuilder = new StringBuilder();
+        for (int i = 0; i < columnCountUpperBound; i++) {
+            // 1 target column
+            inputBuilder.append("1\n");
+            // target column type, will fail due to restrictive settings
+            inputBuilder.append("cleartext\n");
+            // target column type, will succeed
+            inputBuilder.append("fingerprint\n");
+            // target column name
+            inputBuilder.append("column").append(i).append('\n');
+            // skip suffix
+            inputBuilder.append("\n");
+        }
+        final var userInput = new ByteArrayInputStream(inputBuilder.toString().getBytes(StandardCharsets.UTF_8));
+        System.setIn(new BufferedInputStream(userInput));
+
+        final var cleanRoomsDao = mock(CleanRoomsDao.class);
+        when(cleanRoomsDao.getCollaborationDataEncryptionMetadata(any())).thenReturn(ClientSettings.highAssuranceMode());
+
+        assertEquals(0, SchemaMode.getApp(cleanRoomsDao).execute(args.toArrayWithoutMode()));
+
+        assertTrue(schemaPath.toFile().exists());
+        assertTrue(schemaPath.toFile().length() > 0);
+        final String contents = Files.readString(schemaPath);
+        assertTrue(contents.contains("\"headerRow\": " + hasHeaderRow));
+        assertEquals(hasHeaderRow ? expectedTargetColumnCount : 0,
+                StringTestUtility.countMatches("sourceHeader", contents));
+        assertEquals(expectedTargetColumnCount,
+                StringTestUtility.countMatches("targetHeader", contents));
+        assertEquals(0,
                 StringTestUtility.countMatches(ColumnType.CLEARTEXT.toString(), contents));
+        assertEquals(expectedTargetColumnCount,
+                StringTestUtility.countMatches("\"" + ColumnType.FINGERPRINT + "\"", contents));
+    }
+
+    @Test
+    public void schemaTemplateCsvTest() throws IOException {
+        runTemplateGeneratorNoSettings("../samples/csv/data_sample_without_quotes.csv", true);
+    }
+
+    @Test
+    public void schemaTemplateCsvNoHeadersTest() throws IOException {
+        runTemplateGeneratorNoSettings("../samples/csv/data_sample_no_headers.csv", false);
+    }
+
+    @Test
+    public void schemaTemplateWithPermissiveSettingsCsvTest() throws IOException {
+        runTemplateGeneratorPermissiveSettings("../samples/csv/data_sample_without_quotes.csv", true);
+    }
+
+    @Test
+    public void schemaTemplateWithPermissiveSettingsCsvNoHeadersTest() throws IOException {
+        runTemplateGeneratorPermissiveSettings("../samples/csv/data_sample_no_headers.csv", false);
+    }
+
+    @Test
+    public void schemaTemplateWithRestrictiveSettingsCsvTest() throws IOException {
+        runTemplateGeneratorRestrictiveSettings("../samples/csv/data_sample_without_quotes.csv", SAMPLE_DATA_COLUMN_COUNT, true);
+    }
+
+    @Test
+    public void schemaTemplateWithRestrictiveSettingsCsvNoHeadersTest() throws IOException {
+        runTemplateGeneratorRestrictiveSettings("../samples/csv/data_sample_no_headers.csv", SAMPLE_DATA_COLUMN_COUNT, false);
+    }
+
+    @Test
+    public void schemaTemplateParquetTest() throws IOException {
+        runTemplateGeneratorNoSettings("../samples/parquet/data_sample.parquet", true);
+    }
+
+    @Test
+    public void schemaTemplateWithPermissiveSettingsParquetTest() throws IOException {
+        runTemplateGeneratorPermissiveSettings("../samples/parquet/data_sample.parquet", true);
+    }
+
+    @Test
+    public void schemaTemplateWithRestrictiveSettingsParquetTest() throws IOException {
+        runTemplateGeneratorRestrictiveSettings("../samples/parquet/data_sample.parquet", SAMPLE_DATA_COLUMN_COUNT, true);
+    }
+
+    @Test
+    public void schemaTemplateWithRestrictiveSettingsParquetMixedDataTest() throws IOException {
+        // only 1 column is a string, so we only expect 1 target columns
+        runTemplateGeneratorRestrictiveSettings("../samples/parquet/rows_100_groups_10_prim_data.parquet", 1, true);
+    }
+
+    @Test
+    public void schemaInteractiveCsvTest() throws IOException {
+        runInteractiveGeneratorNoSettings("../samples/csv/data_sample_without_quotes.csv", true);
+    }
+
+    // Check that interactive schema command returns results and shallowly check content contains expected entries
+    @Test
+    public void schemaInteractiveCsvNoHeadersTest() throws IOException {
+        runInteractiveGeneratorNoSettings("../samples/csv/data_sample_no_headers.csv", false);
+    }
+
+    @Test
+    public void schemaInteractiveParquetTest() throws IOException {
+        runInteractiveGeneratorNoSettings("../samples/parquet/data_sample.parquet", true);
+    }
+
+    @Test
+    public void schemaInteractivePermissiveSettingsCsvTest() throws IOException {
+        runInteractiveGeneratorPermissiveSettings("../samples/csv/data_sample_without_quotes.csv", true);
+    }
+
+    @Test
+    public void schemaInteractivePermissiveSettingsCsvNoHeadersTest() throws IOException {
+        runInteractiveGeneratorPermissiveSettings("../samples/csv/data_sample_no_headers.csv", false);
+    }
+
+    @Test
+    public void schemaInteractivePermissiveSettingsParquetTest() throws IOException {
+        runInteractiveGeneratorNoSettings("../samples/parquet/data_sample.parquet", true);
+    }
+
+    @Test
+    public void schemaInteractiveRestrictiveSettingsCsvTest() throws IOException {
+        runInteractiveGeneratorRestrictiveSettings("../samples/csv/data_sample_without_quotes.csv", SAMPLE_DATA_COLUMN_COUNT, true);
+    }
+
+    @Test
+    public void schemaInteractiveRestrictiveSettingsCsvNoHeadersTest() throws IOException {
+        runInteractiveGeneratorRestrictiveSettings("../samples/csv/data_sample_no_headers.csv", SAMPLE_DATA_COLUMN_COUNT, false);
+    }
+
+    @Test
+    public void schemaInteractiveRestrictiveSettingsParquetTest() throws IOException {
+        runInteractiveGeneratorRestrictiveSettings("../samples/parquet/data_sample.parquet", SAMPLE_DATA_COLUMN_COUNT, true);
+    }
+
+    @Test
+    public void schemaInteractiveRestrictiveSettingsParquetMixedDataTest() throws IOException {
+        // Only 1 column is of type string, so we expect 1 target column only
+        runInteractiveGeneratorRestrictiveSettings("../samples/parquet/rows_100_groups_10_prim_data.parquet", 1, true);
     }
 }

--- a/c3r-cli/src/test/java/com/amazonaws/c3r/io/schema/InteractiveSchemaGeneratorTest.java
+++ b/c3r-cli/src/test/java/com/amazonaws/c3r/io/schema/InteractiveSchemaGeneratorTest.java
@@ -3,6 +3,7 @@
 
 package com.amazonaws.c3r.io.schema;
 
+import com.amazonaws.c3r.config.ClientSettings;
 import com.amazonaws.c3r.config.ColumnHeader;
 import com.amazonaws.c3r.config.ColumnSchema;
 import com.amazonaws.c3r.config.ColumnType;
@@ -24,6 +25,7 @@ import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -76,6 +78,41 @@ public class InteractiveSchemaGeneratorTest {
                     "      \"sourceHeader\": \"header3\",",
                     "      \"targetHeader\": \"header3\",",
                     "      \"type\": \"sealed\",",
+                    "      \"pad\": {",
+                    "        \"type\": \"MAX\",",
+                    "        \"length\": \"0\"",
+                    "      }",
+                    "    }",
+                    "  ]",
+                    "}");
+
+    private final String exampleMappedSchemaNoCleartextString =
+            String.join("\n",
+                    "{",
+                    "  \"headerRow\": true,",
+                    "  \"columns\": [",
+                    "    {",
+                    "      \"sourceHeader\": \"header2\",",
+                    "      \"targetHeader\": \"targetheader2_sealed\",",
+                    "      \"type\": \"SEALED\",",
+                    "      \"pad\": {",
+                    "        \"type\": \"NONE\"",
+                    "      }",
+                    "    },",
+                    "    {",
+                    "      \"sourceHeader\": \"header2\",",
+                    "      \"targetHeader\": \"targetheader2_fingerprint\",",
+                    "      \"type\": \"FINGERPRINT\"",
+                    "    },",
+                    "    {",
+                    "      \"sourceHeader\": \"header2\",",
+                    "      \"targetHeader\": \"targetheader2\",",
+                    "      \"type\": \"FINGERPRINT\"",
+                    "    },",
+                    "    {",
+                    "      \"sourceHeader\": \"header3\",",
+                    "      \"targetHeader\": \"header3\",",
+                    "      \"type\": \"SEALED\",",
                     "      \"pad\": {",
                     "        \"type\": \"MAX\",",
                     "        \"length\": \"0\"",
@@ -184,7 +221,10 @@ public class InteractiveSchemaGeneratorTest {
     private ByteArrayOutputStream consoleOutput;
 
     // Set up the interactive generator.
-    private void setup(final String simulatedUserInput, final List<ColumnHeader> headers, final List<ClientDataType> types)
+    private void setup(final String simulatedUserInput,
+                       final List<ColumnHeader> headers,
+                       final List<ClientDataType> types,
+                       final ClientSettings clientSettings)
             throws IOException {
         final Path tempDir = Files.createTempDirectory("temp");
         tempDir.toFile().deleteOnExit();
@@ -198,20 +238,21 @@ public class InteractiveSchemaGeneratorTest {
                 .targetJsonFile(targetSchema.toAbsolutePath().toString())
                 .consoleInput(userInput)
                 .consoleOutput(new PrintStream(consoleOutput, true, StandardCharsets.UTF_8))
+                .clientSettings(clientSettings)
                 .build();
     }
 
     @Test
     public void validateErrorWithMismatchedColumnCounts() {
         assertThrows(C3rIllegalArgumentException.class, () ->
-                setup("", headers, List.of()));
+                setup("", headers, List.of(), null));
     }
 
     @Test
     public void promptNonnegativeIntValidTest() throws IOException {
         final List<String> validInputs = List.of("42", "0", "100");
         for (var input : validInputs) {
-            setup(input, headers, stringColumnTypes);
+            setup(input, headers, stringColumnTypes, null);
             assertEquals(
                     Integer.valueOf(input),
                     schemaGen.promptNonNegativeInt("", null, 100));
@@ -223,7 +264,7 @@ public class InteractiveSchemaGeneratorTest {
     public void promptNonnegativeIntInvalidTest() throws IOException {
         final List<String> validInputs = List.of("", "NotANumber", "-1", "101");
         for (var input : validInputs) {
-            setup(input, headers, stringColumnTypes);
+            setup(input, headers, stringColumnTypes, null);
             assertNull(schemaGen.promptNonNegativeInt("", null, 100));
             assertTrue(consoleOutput.toString().toLowerCase().contains("expected"));
         }
@@ -233,7 +274,7 @@ public class InteractiveSchemaGeneratorTest {
     public void promptNonNegativeIntValidDefaultTest() throws IOException {
         final List<String> validInputs = List.of("1", "", "3");
         for (var input : validInputs) {
-            setup(input, headers, stringColumnTypes);
+            setup(input, headers, stringColumnTypes, null);
             assertEquals(
                     input.isBlank() ? 2 : Integer.parseInt(input),
                     schemaGen.promptNonNegativeInt("", 2, 100));
@@ -248,7 +289,7 @@ public class InteractiveSchemaGeneratorTest {
 
         for (var input : validYesStrings) {
             for (var answer : defaultBooleanAnswers) {
-                setup(input, headers, stringColumnTypes);
+                setup(input, headers, stringColumnTypes, null);
                 assertTrue(schemaGen.promptYesOrNo("", answer));
                 assertFalse(consoleOutput.toString().toLowerCase().contains("expected"));
             }
@@ -257,14 +298,14 @@ public class InteractiveSchemaGeneratorTest {
         final List<String> validNoStrings = List.of("n", "no", "N", "NO");
         for (var input : validNoStrings) {
             for (var answer : defaultBooleanAnswers) {
-                setup(input, headers, stringColumnTypes);
+                setup(input, headers, stringColumnTypes, null);
                 assertFalse(schemaGen.promptYesOrNo("", answer));
                 assertFalse(consoleOutput.toString().toLowerCase().contains("expected"));
             }
         }
 
         for (var answer : defaultBooleanAnswers) {
-            setup("", headers, stringColumnTypes);
+            setup("", headers, stringColumnTypes, null);
             assertEquals(answer, schemaGen.promptYesOrNo("", answer));
             if (answer == null) {
                 assertTrue(consoleOutput.toString().toLowerCase().contains("expected"));
@@ -276,15 +317,15 @@ public class InteractiveSchemaGeneratorTest {
 
     @Test
     public void promptYesOrNoInvalidTest() throws IOException {
-        setup("", headers, stringColumnTypes);
+        setup("", headers, stringColumnTypes, null);
         assertNull(schemaGen.promptYesOrNo("", null));
         assertTrue(consoleOutput.toString().toLowerCase().contains("expected"));
 
-        setup("ja", headers, stringColumnTypes);
+        setup("ja", headers, stringColumnTypes, null);
         assertNull(schemaGen.promptYesOrNo("", null));
         assertTrue(consoleOutput.toString().toLowerCase().contains("expected"));
 
-        setup("nein", headers, stringColumnTypes);
+        setup("nein", headers, stringColumnTypes, null);
         assertNull(schemaGen.promptYesOrNo("", null));
         assertTrue(consoleOutput.toString().toLowerCase().contains("expected"));
     }
@@ -292,22 +333,51 @@ public class InteractiveSchemaGeneratorTest {
     @Test
     public void promptColumnTypeValidTest() throws IOException {
         final List<String> validCleartextInputs = List.of("c", "C", "cleartext", "CLEARTEXT");
+        final List<ClientSettings> permissiveSettings = new ArrayList<>();
+        permissiveSettings.add(null);
+        permissiveSettings.add(ClientSettings.lowAssuranceMode());
+        for (var settings : permissiveSettings) {
+            for (var input : validCleartextInputs) {
+                setup(input, headers, stringColumnTypes, settings);
+                assertEquals(ColumnType.CLEARTEXT, schemaGen.promptColumnType());
+                assertFalse(consoleOutput.toString().toLowerCase().contains("expected"));
+            }
+
+            final List<String> validFingerprintInputs = List.of("f", "F", "fingerprint", "FINGERPRINT");
+            for (var input : validFingerprintInputs) {
+                setup(input, headers, stringColumnTypes, settings);
+                assertEquals(ColumnType.FINGERPRINT, schemaGen.promptColumnType());
+                assertFalse(consoleOutput.toString().toLowerCase().contains("expected"));
+            }
+
+            final List<String> validSealedInputs = List.of("s", "S", "sealed", "SEALED");
+            for (var input : validSealedInputs) {
+                setup(input, headers, stringColumnTypes, settings);
+                assertEquals(ColumnType.SEALED, schemaGen.promptColumnType());
+                assertFalse(consoleOutput.toString().toLowerCase().contains("expected"));
+            }
+        }
+    }
+
+    @Test
+    public void promptColumnTypeRestrictiveSettingsTest() throws IOException {
+        final List<String> validCleartextInputs = List.of("c", "C", "cleartext", "CLEARTEXT");
         for (var input : validCleartextInputs) {
-            setup(input, headers, stringColumnTypes);
-            assertEquals(ColumnType.CLEARTEXT, schemaGen.promptColumnType());
-            assertFalse(consoleOutput.toString().toLowerCase().contains("expected"));
+            setup(input, headers, stringColumnTypes, ClientSettings.highAssuranceMode());
+            assertNull(schemaGen.promptColumnType());
+            assertTrue(consoleOutput.toString().toLowerCase().contains("expected"));
         }
 
         final List<String> validFingerprintInputs = List.of("f", "F", "fingerprint", "FINGERPRINT");
         for (var input : validFingerprintInputs) {
-            setup(input, headers, stringColumnTypes);
+            setup(input, headers, stringColumnTypes, ClientSettings.highAssuranceMode());
             assertEquals(ColumnType.FINGERPRINT, schemaGen.promptColumnType());
             assertFalse(consoleOutput.toString().toLowerCase().contains("expected"));
         }
 
         final List<String> validSealedInputs = List.of("s", "S", "sealed", "SEALED");
         for (var input : validSealedInputs) {
-            setup(input, headers, stringColumnTypes);
+            setup(input, headers, stringColumnTypes, ClientSettings.highAssuranceMode());
             assertEquals(ColumnType.SEALED, schemaGen.promptColumnType());
             assertFalse(consoleOutput.toString().toLowerCase().contains("expected"));
         }
@@ -317,7 +387,7 @@ public class InteractiveSchemaGeneratorTest {
     public void promptColumnTypeInvalidTest() throws IOException {
         final List<String> validCleartextInputs = List.of("", "a", "unrostricted", "solekt", "joyn");
         for (var input : validCleartextInputs) {
-            setup(input, headers, stringColumnTypes);
+            setup(input, headers, stringColumnTypes, null);
             assertNull(schemaGen.promptColumnType());
             assertTrue(consoleOutput.toString().toLowerCase().contains("expected"));
         }
@@ -325,44 +395,44 @@ public class InteractiveSchemaGeneratorTest {
 
     @Test
     public void promptTargetHeaderSuffixTest() throws IOException {
-        setup("", headers, stringColumnTypes);
+        setup("", headers, stringColumnTypes, null);
         assertNull(schemaGen.promptTargetHeaderSuffix(ColumnType.CLEARTEXT));
         assertFalse(consoleOutput.toString().toLowerCase().contains("expected"));
 
-        setup("y", headers, stringColumnTypes);
+        setup("y", headers, stringColumnTypes, null);
         assertEquals("_sealed", schemaGen.promptTargetHeaderSuffix(ColumnType.SEALED));
         assertFalse(consoleOutput.toString().toLowerCase().contains("expected"));
 
-        setup("n", headers, stringColumnTypes);
+        setup("n", headers, stringColumnTypes, null);
         assertNull(schemaGen.promptTargetHeaderSuffix(ColumnType.SEALED));
         assertFalse(consoleOutput.toString().toLowerCase().contains("expected"));
 
-        setup("", headers, stringColumnTypes);
+        setup("", headers, stringColumnTypes, null);
         assertEquals("_fingerprint", schemaGen.promptTargetHeaderSuffix(ColumnType.FINGERPRINT));
         assertFalse(consoleOutput.toString().toLowerCase().contains("expected"));
 
-        setup("n", headers, stringColumnTypes);
+        setup("n", headers, stringColumnTypes, null);
         assertNull(schemaGen.promptTargetHeaderSuffix(ColumnType.FINGERPRINT));
         assertFalse(consoleOutput.toString().toLowerCase().contains("expected"));
     }
 
     @Test
     public void promptTargetHeaderTest() throws IOException {
-        setup("", headers, stringColumnTypes);
+        setup("", headers, stringColumnTypes, null);
         assertEquals(new ColumnHeader("a"), schemaGen.promptTargetHeader(new ColumnHeader("a"), ColumnType.CLEARTEXT));
         assertFalse(consoleOutput.toString().toLowerCase().contains("expected"));
 
-        setup("b", headers, stringColumnTypes);
+        setup("b", headers, stringColumnTypes, null);
         assertEquals(new ColumnHeader("b"), schemaGen.promptTargetHeader(new ColumnHeader("a"), ColumnType.CLEARTEXT));
         assertFalse(consoleOutput.toString().toLowerCase().contains("expected"));
         assertFalse(consoleOutput.toString().toLowerCase().contains("normalized"));
 
-        setup("B", headers, stringColumnTypes);
+        setup("B", headers, stringColumnTypes, null);
         assertEquals(new ColumnHeader("b"), schemaGen.promptTargetHeader(new ColumnHeader("a"), ColumnType.CLEARTEXT));
         assertFalse(consoleOutput.toString().toLowerCase().contains("expected"));
         assertTrue(consoleOutput.toString().toLowerCase().contains("normalized"));
 
-        setup("b".repeat(Limits.GLUE_MAX_HEADER_UTF8_BYTE_LENGTH) + 1, headers, stringColumnTypes);
+        setup("b".repeat(Limits.GLUE_MAX_HEADER_UTF8_BYTE_LENGTH) + 1, headers, stringColumnTypes, null);
         assertNull(schemaGen.promptTargetHeader(new ColumnHeader("a"), ColumnType.CLEARTEXT));
         assertTrue(consoleOutput.toString().toLowerCase().contains("expected"));
     }
@@ -370,16 +440,16 @@ public class InteractiveSchemaGeneratorTest {
     @Test
     public void promptTargetHeaderWithoutSourceHeadersTest() throws IOException {
         // empty input does _not_ give you a default target header when no source headers exist
-        setup("", null, stringColumnTypes);
+        setup("", null, stringColumnTypes, null);
         assertNull(schemaGen.promptTargetHeader(null, ColumnType.CLEARTEXT));
         assertTrue(consoleOutput.toString().toLowerCase().contains("expected"));
 
         // providing input for a target header when source headers are null remains unchanged
-        setup("b", headers, stringColumnTypes);
+        setup("b", headers, stringColumnTypes, null);
         assertEquals(new ColumnHeader("b"), schemaGen.promptTargetHeader(null, ColumnType.CLEARTEXT));
         assertFalse(consoleOutput.toString().toLowerCase().contains("expected"));
 
-        setup("B", headers, stringColumnTypes);
+        setup("B", headers, stringColumnTypes, null);
         assertEquals(new ColumnHeader("b"), schemaGen.promptTargetHeader(null, ColumnType.CLEARTEXT));
         assertFalse(consoleOutput.toString().toLowerCase().contains("expected"));
         assertTrue(consoleOutput.toString().toLowerCase().contains("normalized"));
@@ -387,7 +457,7 @@ public class InteractiveSchemaGeneratorTest {
 
     @Test
     public void promptTargetHeaderAlreadyUsedHeaderTest() throws IOException {
-        setup("\n", headers, stringColumnTypes);
+        setup("\n", headers, stringColumnTypes, null);
         assertEquals(new ColumnHeader("header"), schemaGen.promptTargetHeader(new ColumnHeader("header"), ColumnType.CLEARTEXT));
         assertFalse(consoleOutput.toString().toLowerCase().contains("expected"));
 
@@ -398,14 +468,14 @@ public class InteractiveSchemaGeneratorTest {
     @Test
     public void promptTargetHeaderWithSuffixTest() throws IOException {
         final String suffix = ColumnHeader.DEFAULT_FINGERPRINT_SUFFIX;
-        setup("\n", headers, stringColumnTypes);
+        setup("\n", headers, stringColumnTypes, null);
         assertEquals(
                 new ColumnHeader("a_fingerprint"),
                 schemaGen.promptTargetHeader(new ColumnHeader("a"), ColumnType.FINGERPRINT));
         assertFalse(consoleOutput.toString().toLowerCase().contains("expected"));
 
         setup("b".repeat(Limits.GLUE_MAX_HEADER_UTF8_BYTE_LENGTH - suffix.length())
-                + "\n", headers, stringColumnTypes);
+                + "\n", headers, stringColumnTypes, null);
         assertEquals(
                 new ColumnHeader(
                         "b".repeat(Limits.GLUE_MAX_HEADER_UTF8_BYTE_LENGTH - suffix.length())
@@ -417,7 +487,7 @@ public class InteractiveSchemaGeneratorTest {
     @Test
     public void promptTargetHeaderCannotAddSuffixTest() throws IOException {
         setup("a".repeat(Limits.GLUE_MAX_HEADER_UTF8_BYTE_LENGTH)
-                + "\n", headers, stringColumnTypes);
+                + "\n", headers, stringColumnTypes, null);
         assertNull(schemaGen.promptTargetHeader(new ColumnHeader("a"), ColumnType.FINGERPRINT));
         assertTrue(consoleOutput.toString().toLowerCase().contains("unable to add header suffix"));
     }
@@ -426,39 +496,39 @@ public class InteractiveSchemaGeneratorTest {
     public void promptPadTypeTest() throws IOException {
         final var header = new ColumnHeader("a");
         final PadType nullDefaultType = null;
-        setup("", headers, stringColumnTypes);
+        setup("", headers, stringColumnTypes, null);
         assertNull(schemaGen.promptPadType(header, nullDefaultType));
         assertTrue(consoleOutput.toString().toLowerCase().contains("expected"));
 
-        setup("", headers, stringColumnTypes);
+        setup("", headers, stringColumnTypes, null);
         assertEquals(PadType.MAX, schemaGen.promptPadType(header, PadType.MAX));
         assertFalse(consoleOutput.toString().toLowerCase().contains("expected"));
 
-        setup("n", headers, stringColumnTypes);
+        setup("n", headers, stringColumnTypes, null);
         assertEquals(PadType.NONE, schemaGen.promptPadType(header, nullDefaultType));
         assertFalse(consoleOutput.toString().toLowerCase().contains("expected"));
 
-        setup("none", headers, stringColumnTypes);
+        setup("none", headers, stringColumnTypes, null);
         assertEquals(PadType.NONE, schemaGen.promptPadType(header, nullDefaultType));
         assertFalse(consoleOutput.toString().toLowerCase().contains("expected"));
 
-        setup("f", headers, stringColumnTypes);
+        setup("f", headers, stringColumnTypes, null);
         assertEquals(PadType.FIXED, schemaGen.promptPadType(header, nullDefaultType));
         assertFalse(consoleOutput.toString().toLowerCase().contains("expected"));
 
-        setup("fixed", headers, stringColumnTypes);
+        setup("fixed", headers, stringColumnTypes, null);
         assertEquals(PadType.FIXED, schemaGen.promptPadType(header, nullDefaultType));
         assertFalse(consoleOutput.toString().toLowerCase().contains("expected"));
 
-        setup("m", headers, stringColumnTypes);
+        setup("m", headers, stringColumnTypes, null);
         assertEquals(PadType.MAX, schemaGen.promptPadType(header, nullDefaultType));
         assertFalse(consoleOutput.toString().toLowerCase().contains("expected"));
 
-        setup("max", headers, stringColumnTypes);
+        setup("max", headers, stringColumnTypes, null);
         assertEquals(PadType.MAX, schemaGen.promptPadType(header, nullDefaultType));
         assertFalse(consoleOutput.toString().toLowerCase().contains("expected"));
 
-        setup("unknown", headers, stringColumnTypes);
+        setup("unknown", headers, stringColumnTypes, null);
         assertNull(schemaGen.promptPadType(header, nullDefaultType));
         assertTrue(consoleOutput.toString().toLowerCase().contains("expected"));
     }
@@ -466,19 +536,19 @@ public class InteractiveSchemaGeneratorTest {
     @Test
     public void promptPadTest() throws IOException {
         final var header = new ColumnHeader("a");
-        setup("n", headers, stringColumnTypes);
+        setup("n", headers, stringColumnTypes, null);
         assertEquals(
                 Pad.DEFAULT,
                 schemaGen.promptPad(header));
         assertFalse(consoleOutput.toString().toLowerCase().contains("expected"));
 
-        setup("f\n42", headers, stringColumnTypes);
+        setup("f\n42", headers, stringColumnTypes, null);
         assertEquals(
                 Pad.builder().type(PadType.FIXED).length(42).build(),
                 schemaGen.promptPad(header));
         assertFalse(consoleOutput.toString().toLowerCase().contains("expected"));
 
-        setup("m\n42", headers, stringColumnTypes);
+        setup("m\n42", headers, stringColumnTypes, null);
         assertEquals(
                 Pad.builder().type(PadType.MAX).length(42).build(),
                 schemaGen.promptPad(header));
@@ -497,7 +567,7 @@ public class InteractiveSchemaGeneratorTest {
                         useSuffix,
                         paddingType),
                 headers,
-                stringColumnTypes);
+                stringColumnTypes, null);
         assertEquals(
                 ColumnSchema.builder()
                         .sourceHeader(new ColumnHeader("source"))
@@ -511,7 +581,7 @@ public class InteractiveSchemaGeneratorTest {
 
     @Test
     public void promptColumnInfoWithSourceHeadersAndUnknownTypeTest() throws IOException {
-        setup("target", headers, unknownColumnTypes);
+        setup("target", headers, unknownColumnTypes, null);
         assertEquals(
                 ColumnSchema.builder()
                         .sourceHeader(new ColumnHeader("source"))
@@ -525,7 +595,7 @@ public class InteractiveSchemaGeneratorTest {
 
     @Test
     public void promptColumnInfoWithoutSourceHeadersTest() throws IOException {
-        setup("", null, stringColumnTypes);
+        setup("", null, stringColumnTypes, null);
         final String columnType = "sealed";
         final String targetName = "target";
         final String useSuffix = "no";
@@ -536,7 +606,7 @@ public class InteractiveSchemaGeneratorTest {
                         useSuffix,
                         paddingType),
                 headers,
-                stringColumnTypes);
+                stringColumnTypes, null);
         assertEquals(
                 ColumnSchema.builder()
                         .sourceHeader(null)
@@ -550,7 +620,7 @@ public class InteractiveSchemaGeneratorTest {
 
     @Test
     public void promptColumnInfoWithoutSourceHeadersAndUnknownTypeTest() throws IOException {
-        setup("target", null, unknownColumnTypes);
+        setup("target", null, unknownColumnTypes, null);
         assertEquals(
                 ColumnSchema.builder()
                         .targetHeader(new ColumnHeader("target"))
@@ -564,7 +634,7 @@ public class InteractiveSchemaGeneratorTest {
     @Test
     public void runGenerateNoSchemaTest() throws IOException {
         // 0 target columns to generate for each source column
-        setup("0\n".repeat(headers.size()), headers, stringColumnTypes);
+        setup("0\n".repeat(headers.size()), headers, stringColumnTypes, null);
         schemaGen.run();
         assertTrue(consoleOutput.toString().contains("No target columns were specified."));
         assertEquals(0, targetSchema.toFile().length());
@@ -598,7 +668,7 @@ public class InteractiveSchemaGeneratorTest {
                         "max", // header3, column 1 padding type
                         "" // header3, column 1 padding length (default 0)
                 );
-        setup(userInput, headers, stringColumnTypes);
+        setup(userInput, headers, stringColumnTypes, null);
         schemaGen.run();
         assertNotEquals(0, targetSchema.toFile().length());
 
@@ -629,10 +699,9 @@ public class InteractiveSchemaGeneratorTest {
                         // type is cleartext due to unknown client type
                         "" // header3, column 1 target header (default)
                 );
-        setup(userInput, headers, unknownColumnTypes);
+        setup(userInput, headers, unknownColumnTypes, null);
         schemaGen.run();
         assertNotEquals(0, targetSchema.toFile().length());
-        System.err.println("Expected: " + exampleMappedSchemaAllCleartextString);
 
         final var expectedSchema = GsonUtil.fromJson(exampleMappedSchemaAllCleartextString, TableSchema.class);
         final var actualSchema = GsonUtil.fromJson(FileUtil.readBytes(targetSchema.toAbsolutePath().toString()), TableSchema.class);
@@ -667,7 +736,7 @@ public class InteractiveSchemaGeneratorTest {
                         "max", // header3, column 1 padding type
                         "" // header3, column 1 padding length (default 0)
                 );
-        setup(userInput, null, stringColumnTypes);
+        setup(userInput, null, stringColumnTypes, null);
         schemaGen.run();
         assertNotEquals(0, targetSchema.toFile().length());
 
@@ -698,7 +767,7 @@ public class InteractiveSchemaGeneratorTest {
                         // type is cleartext due to unknown client type
                         "targetHeader3" // header3, column 1 target header (default)
                 );
-        setup(userInput, null, unknownColumnTypes);
+        setup(userInput, null, unknownColumnTypes, null);
         schemaGen.run();
         assertNotEquals(0, targetSchema.toFile().length());
 
@@ -750,7 +819,7 @@ public class InteractiveSchemaGeneratorTest {
                         "zero", // header3, column 1 padding length (default 0)
                         "" // header3, column 1 padding length (default 0)
                 );
-        setup(userInput, headers, stringColumnTypes);
+        setup(userInput, headers, stringColumnTypes, null);
         schemaGen.run();
         assertNotEquals(0, targetSchema.toFile().length());
 
@@ -783,4 +852,141 @@ public class InteractiveSchemaGeneratorTest {
                 .targetJsonFile(targetSchema.toFile().getAbsolutePath())
                 .hasHeaders(true).build());
     }
+
+    @Test
+    public void runGenerateSchemaWithSourceHeadersPermissiveSettingsTest() throws IOException {
+        final String userInput =
+                String.join("\n",
+                        // source header1
+                        "0", // number of columns for header1
+                        // source header2
+                        "3", // number of columns for header2
+                        // header2, column 1
+                        "sealed", // header2, column 1 type
+                        "targetHeader2", // header2, column 1 target header
+                        "yes", // header2, column 1 use suffix
+                        "none", // header2, column 1 padding type
+                        // header2, column 2
+                        "fingerprint", // header2, column 2 type
+                        "targetHeader2", // header2, column 2 target header
+                        "yes", // header2, column 2 use suffix
+                        // header2, column 3
+                        "cleartext", // header2, column 3 type
+                        "targetHeader2", // header2, column 3 target header
+                        // source header3
+                        "", // number of columns for header3 (default to 1)
+                        "sealed",
+                        "", // header3, column 1 target header (default)
+                        "n", // header3, column 1 use suffix
+                        "max", // header3, column 1 padding type
+                        "" // header3, column 1 padding length (default 0)
+                );
+        setup(userInput, headers, stringColumnTypes, ClientSettings.lowAssuranceMode());
+        schemaGen.run();
+        assertNotEquals(0, targetSchema.toFile().length());
+
+        final var expectedSchema = GsonUtil.fromJson(exampleMappedSchemaString, TableSchema.class);
+        final var actualSchema = GsonUtil.fromJson(FileUtil.readBytes(targetSchema.toAbsolutePath().toString()), TableSchema.class);
+        assertEquals(GsonUtil.toJson(expectedSchema), GsonUtil.toJson((actualSchema)));
+    }
+
+    @Test
+    public void runGenerateSchemaWithSourceHeadersRestrictiveSettingsTest() throws IOException {
+        final String userInput =
+                String.join("\n",
+                        // source header1
+                        "0", // number of columns for header1
+                        // source header2
+                        "3", // number of columns for header2
+                        // header2, column 1
+                        "sealed", // header2, column 1 type
+                        "targetHeader2", // header2, column 1 target header
+                        "yes", // header2, column 1 use suffix
+                        "none", // header2, column 1 padding type
+                        // header2, column 2
+                        "fingerprint", // header2, column 2 type
+                        "targetHeader2", // header2, column 2 target header
+                        "yes", // header2, column 2 use suffix
+                        // header2, column 3
+                        "cleartext", // header2, column 3 type, NOT ALLOWED
+                        "fingerprint",
+                        "targetHeader2", // header2, column 3 target header
+                        "n", // header2, column 3 use suffix
+                        // source header3
+                        "", // number of columns for header3 (default to 1)
+                        "sealed",
+                        "", // header3, column 1 target header (default)
+                        "n", // header3, column 1 use suffix
+                        "max", // header3, column 1 padding type
+                        "" // header3, column 1 padding length (default 0)
+                );
+        setup(userInput, headers, stringColumnTypes, ClientSettings.highAssuranceMode());
+        schemaGen.run();
+        assertNotEquals(0, targetSchema.toFile().length());
+
+        final var expectedSchema = GsonUtil.fromJson(exampleMappedSchemaNoCleartextString, TableSchema.class);
+        final var actualSchema = GsonUtil.fromJson(FileUtil.readBytes(targetSchema.toAbsolutePath().toString()), TableSchema.class);
+        assertEquals(GsonUtil.toJson(expectedSchema), GsonUtil.toJson((actualSchema)));
+    }
+
+    @Test
+    public void runGenerateSchemaWithSourceHeadersUnknownTypesPermissiveSettingsTest() throws IOException {
+        final String userInput =
+                String.join("\n",
+                        // source header1
+                        "0", // number of columns for header1
+                        // source header2
+                        "3", // number of columns for header2
+                        // header2, column 1
+                        // type is cleartext due to unknown client type
+                        "targetHeader2_1", // header2, column 1 target header
+                        // header2, column 2
+                        // type is cleartext due to unknown client type
+                        "targetHeader2_2", // header2, column 2 target header
+                        // header2, column 3
+                        // type is cleartext due to unknown client type
+                        "targetHeader2_3", // header2, column 2 target header
+                        // source header3
+                        "", // number of columns for header3 (default to 1)
+                        // type is cleartext due to unknown client type
+                        "" // header3, column 1 target header (default)
+                );
+        setup(userInput, headers, unknownColumnTypes, ClientSettings.lowAssuranceMode());
+        schemaGen.run();
+        assertNotEquals(0, targetSchema.toFile().length());
+
+        final var expectedSchema = GsonUtil.fromJson(exampleMappedSchemaAllCleartextString, TableSchema.class);
+        final var actualSchema = GsonUtil.fromJson(FileUtil.readBytes(targetSchema.toAbsolutePath().toString()), TableSchema.class);
+        assertEquals(GsonUtil.toJson(expectedSchema), GsonUtil.toJson((actualSchema)));
+    }
+
+    @Test
+    public void runGenerateSchemaWithSourceHeadersUnknownTypesRestrictiveSettingsTest() throws IOException {
+        final String userInput =
+                String.join("\n",
+                        // source header1
+                        "0", // number of columns for header1
+                        // source header2
+                        "3", // number of columns for header2
+                        // header2, column 1
+                        // type is cleartext due to unknown client type
+                        "targetHeader2_1", // header2, column 1 target header
+                        // header2, column 2
+                        // type is cleartext due to unknown client type
+                        "targetHeader2_2", // header2, column 2 target header
+                        // header2, column 3
+                        // type is cleartext due to unknown client type
+                        "targetHeader2_3", // header2, column 2 target header
+                        // source header3
+                        "", // number of columns for header3 (default to 1)
+                        // type is cleartext due to unknown client type
+                        "" // header3, column 1 target header (default)
+                );
+        setup(userInput, headers, unknownColumnTypes, ClientSettings.highAssuranceMode());
+
+        schemaGen.run();
+        assertTrue(consoleOutput.toString().contains("No source columns could be considered for output"));
+        assertEquals(0, targetSchema.toFile().length());
+    }
+
 }

--- a/c3r-cli/src/test/java/com/amazonaws/c3r/io/schema/ParquetSchemaGeneratorTest.java
+++ b/c3r-cli/src/test/java/com/amazonaws/c3r/io/schema/ParquetSchemaGeneratorTest.java
@@ -13,6 +13,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -48,6 +49,21 @@ public class ParquetSchemaGeneratorTest {
         assertEquals(
                 Collections.nCopies(GeneralTestUtility.DATA_SAMPLE_HEADERS.size(), ClientDataType.STRING),
                 getTestSchemaGenerator("../samples/parquet/data_sample.parquet").getSourceColumnTypes());
+    }
+
+    @Test
+    public void getSourceColumnTypesTest() {
+        assertEquals(
+                List.of(ClientDataType.UNKNOWN,
+                        ClientDataType.STRING,
+                        ClientDataType.UNKNOWN,
+                        ClientDataType.UNKNOWN,
+                        ClientDataType.UNKNOWN,
+                        ClientDataType.UNKNOWN,
+                        ClientDataType.UNKNOWN,
+                        ClientDataType.UNKNOWN,
+                        ClientDataType.UNKNOWN),
+                getTestSchemaGenerator("../samples/parquet/rows_100_groups_10_prim_data.parquet").getSourceColumnTypes());
     }
 
     @Test

--- a/c3r-cli/src/test/java/com/amazonaws/c3r/io/schema/TemplateSchemaGeneratorTest.java
+++ b/c3r-cli/src/test/java/com/amazonaws/c3r/io/schema/TemplateSchemaGeneratorTest.java
@@ -3,6 +3,7 @@
 
 package com.amazonaws.c3r.io.schema;
 
+import com.amazonaws.c3r.config.ClientSettings;
 import com.amazonaws.c3r.config.ColumnHeader;
 import com.amazonaws.c3r.data.ClientDataType;
 import com.amazonaws.c3r.exception.C3rIllegalArgumentException;
@@ -40,7 +41,7 @@ public class TemplateSchemaGeneratorTest {
     }
 
     @Test
-    public void testTemplateWithSourceHeadersGeneration() throws IOException {
+    public void testTemplateWithSourceHeadersNoSettingsGeneration() throws IOException {
         final var expectedContent = String.join("\n",
                 "{",
                 "  \"headerRow\": true,",
@@ -48,7 +49,7 @@ public class TemplateSchemaGeneratorTest {
                 "    {",
                 "      \"sourceHeader\": \"header1\",",
                 "      \"targetHeader\": \"header1\",",
-                "      \"type\": \"[cleartext|sealed|fingerprint]\",",
+                "      \"type\": \"[sealed|fingerprint|cleartext]\",",
                 "      \"pad\": {",
                 "        \"COMMENT\": \"omit this pad entry unless column type is sealed\",",
                 "        \"type\": \"[none|fixed|max]\",",
@@ -64,7 +65,6 @@ public class TemplateSchemaGeneratorTest {
                 "}"
         );
 
-        final Path tempSchema = Files.createTempFile("schema", "json");
         final var headers = List.of(
                 new ColumnHeader("header1"),
                 new ColumnHeader("header2")
@@ -82,7 +82,7 @@ public class TemplateSchemaGeneratorTest {
     }
 
     @Test
-    public void testTemplateWithoutSourceHeadersGeneration() throws IOException {
+    public void testTemplateWithoutSourceHeadersNoSettingsGeneration() throws IOException {
         final String expectedPositionalSchemaOutput = String.join("\n",
                 "{",
                 "  \"headerRow\": false,",
@@ -90,7 +90,7 @@ public class TemplateSchemaGeneratorTest {
                 "    [",
                 "      {",
                 "        \"targetHeader\": \"column 1\",",
-                "        \"type\": \"[cleartext|sealed|fingerprint]\",",
+                "        \"type\": \"[sealed|fingerprint|cleartext]\",",
                 "        \"pad\": {",
                 "          \"COMMENT\": \"omit this pad entry unless column type is sealed\",",
                 "          \"type\": \"[none|fixed|max]\",",
@@ -113,6 +113,160 @@ public class TemplateSchemaGeneratorTest {
                 .sourceHeaders(null)
                 .sourceColumnTypes(types)
                 .targetJsonFile(tempSchema.toAbsolutePath().toString())
+                .build()
+                .run();
+        final String content = Files.readString(tempSchema);
+
+        assertEquals(expectedPositionalSchemaOutput, content);
+    }
+
+    @Test
+    public void testTemplateWithSourceHeadersPermissiveSettingsGeneration() throws IOException {
+        final var expectedContent = String.join("\n",
+                "{",
+                "  \"headerRow\": true,",
+                "  \"columns\": [",
+                "    {",
+                "      \"sourceHeader\": \"header1\",",
+                "      \"targetHeader\": \"header1\",",
+                "      \"type\": \"[sealed|fingerprint|cleartext]\",",
+                "      \"pad\": {",
+                "        \"COMMENT\": \"omit this pad entry unless column type is sealed\",",
+                "        \"type\": \"[none|fixed|max]\",",
+                "        \"length\": \"omit length property for type none, otherwise specify value in [0, 10000]\"",
+                "      }",
+                "    },",
+                "    {",
+                "      \"sourceHeader\": \"header2\",",
+                "      \"targetHeader\": \"header2\",",
+                "      \"type\": \"cleartext\"",
+                "    }",
+                "  ]",
+                "}"
+        );
+
+        final var headers = List.of(
+                new ColumnHeader("header1"),
+                new ColumnHeader("header2")
+        );
+        final List<ClientDataType> types = List.of(ClientDataType.STRING, ClientDataType.UNKNOWN);
+        final var generator = TemplateSchemaGenerator.builder()
+                .sourceHeaders(headers)
+                .sourceColumnTypes(types)
+                .targetJsonFile(tempSchema.toAbsolutePath().toString())
+                .clientSettings(ClientSettings.lowAssuranceMode())
+                .build();
+        generator.run();
+        final String content = Files.readString(tempSchema, StandardCharsets.UTF_8);
+
+        assertEquals(expectedContent, content);
+    }
+
+    @Test
+    public void testTemplateWithoutSourceHeadersPermissiveSettingsGeneration() throws IOException {
+        final String expectedPositionalSchemaOutput = String.join("\n",
+                "{",
+                "  \"headerRow\": false,",
+                "  \"columns\": [",
+                "    [",
+                "      {",
+                "        \"targetHeader\": \"column 1\",",
+                "        \"type\": \"[sealed|fingerprint|cleartext]\",",
+                "        \"pad\": {",
+                "          \"COMMENT\": \"omit this pad entry unless column type is sealed\",",
+                "          \"type\": \"[none|fixed|max]\",",
+                "          \"length\": \"omit length property for type none, otherwise specify value in [0, 10000]\"",
+                "        }",
+                "      }",
+                "    ],",
+                "    [",
+                "      {",
+                "        \"targetHeader\": \"column 2\",",
+                "        \"type\": \"cleartext\"",
+                "      }",
+                "    ]",
+                "  ]",
+                "}");
+
+        final List<ClientDataType> types = List.of(ClientDataType.STRING, ClientDataType.UNKNOWN);
+
+        TemplateSchemaGenerator.builder()
+                .sourceHeaders(null)
+                .sourceColumnTypes(types)
+                .targetJsonFile(tempSchema.toAbsolutePath().toString())
+                .clientSettings(ClientSettings.lowAssuranceMode())
+                .build()
+                .run();
+        final String content = Files.readString(tempSchema);
+
+        assertEquals(expectedPositionalSchemaOutput, content);
+    }
+
+    @Test
+    public void testTemplateWithSourceHeadersRestrictiveSettingsGeneration() throws IOException {
+        final var expectedContent = String.join("\n",
+                "{",
+                "  \"headerRow\": true,",
+                "  \"columns\": [",
+                "    {",
+                "      \"sourceHeader\": \"header1\",",
+                "      \"targetHeader\": \"header1\",",
+                "      \"type\": \"[sealed|fingerprint]\",",
+                "      \"pad\": {",
+                "        \"COMMENT\": \"omit this pad entry unless column type is sealed\",",
+                "        \"type\": \"[none|fixed|max]\",",
+                "        \"length\": \"omit length property for type none, otherwise specify value in [0, 10000]\"",
+                "      }",
+                "    }",
+                "  ]",
+                "}"
+        );
+
+        final var headers = List.of(
+                new ColumnHeader("header1"),
+                new ColumnHeader("header2")
+        );
+        final List<ClientDataType> types = List.of(ClientDataType.STRING, ClientDataType.UNKNOWN);
+        final var generator = TemplateSchemaGenerator.builder()
+                .sourceHeaders(headers)
+                .sourceColumnTypes(types)
+                .targetJsonFile(tempSchema.toAbsolutePath().toString())
+                .clientSettings(ClientSettings.highAssuranceMode())
+                .build();
+        generator.run();
+        final String content = Files.readString(tempSchema, StandardCharsets.UTF_8);
+
+        assertEquals(expectedContent, content);
+    }
+
+    @Test
+    public void testTemplateWithoutSourceHeadersRestrictiveSettingsGeneration() throws IOException {
+        final String expectedPositionalSchemaOutput = String.join("\n",
+                "{",
+                "  \"headerRow\": false,",
+                "  \"columns\": [",
+                "    [",
+                "      {",
+                "        \"targetHeader\": \"column 1\",",
+                "        \"type\": \"[sealed|fingerprint]\",",
+                "        \"pad\": {",
+                "          \"COMMENT\": \"omit this pad entry unless column type is sealed\",",
+                "          \"type\": \"[none|fixed|max]\",",
+                "          \"length\": \"omit length property for type none, otherwise specify value in [0, 10000]\"",
+                "        }",
+                "      }",
+                "    ],",
+                "    []",
+                "  ]",
+                "}");
+
+        final List<ClientDataType> types = List.of(ClientDataType.STRING, ClientDataType.UNKNOWN);
+
+        TemplateSchemaGenerator.builder()
+                .sourceHeaders(null)
+                .sourceColumnTypes(types)
+                .targetJsonFile(tempSchema.toAbsolutePath().toString())
+                .clientSettings(ClientSettings.highAssuranceMode())
                 .build()
                 .run();
         final String content = Files.readString(tempSchema);

--- a/c3r-sdk-core/src/main/java/com/amazonaws/c3r/io/CsvRowReader.java
+++ b/c3r-sdk-core/src/main/java/com/amazonaws/c3r/io/CsvRowReader.java
@@ -172,8 +172,10 @@ public final class CsvRowReader extends RowReader<CsvValue> {
                 throw new C3rRuntimeException("Could not read a CSV line from the file " + csvFileName);
             }
             return firstLine.length;
-        } catch (TextParsingException | IOException e) {
-            throw new C3rRuntimeException("Could not get CSV column count from file " + csvFileName, e);
+        } catch (TextParsingException e) {
+            throw new C3rRuntimeException("Could not get column count: an error occurred while parsing " + csvFileName, e);
+        } catch (IOException e) {
+            throw new C3rRuntimeException("Could not get column count: an I/O error occurred while reading " + csvFileName, e);
         }
     }
 

--- a/c3r-sdk-parquet/src/test/java/com/amazonaws/c3r/data/ParquetDataTypeTest.java
+++ b/c3r-sdk-parquet/src/test/java/com/amazonaws/c3r/data/ParquetDataTypeTest.java
@@ -72,6 +72,18 @@ public class ParquetDataTypeTest {
     }
 
     @Test
+    public void supportsCryptoComputingTest() {
+        assertTrue(ParquetDataType.fromType(OPTIONAL_STRING_TYPE).getClientDataType().supportsCryptographicComputing());
+        assertTrue(ParquetDataType.fromType(REQUIRED_STRING_TYPE).getClientDataType().supportsCryptographicComputing());
+        assertFalse(ParquetDataType.fromType(REQUIRED_BINARY_TYPE).getClientDataType().supportsCryptographicComputing());
+        assertFalse(ParquetDataType.fromType(REQUIRED_BOOLEAN_TYPE).getClientDataType().supportsCryptographicComputing());
+        assertFalse(ParquetDataType.fromType(REQUIRED_DOUBLE_TYPE).getClientDataType().supportsCryptographicComputing());
+        assertFalse(ParquetDataType.fromType(REQUIRED_FLOAT_TYPE).getClientDataType().supportsCryptographicComputing());
+        assertFalse(ParquetDataType.fromType(REQUIRED_INT32_TYPE).getClientDataType().supportsCryptographicComputing());
+        assertFalse(ParquetDataType.fromType(REQUIRED_INT64_TYPE).getClientDataType().supportsCryptographicComputing());
+    }
+
+    @Test
     public void fromTypeTest() {
         assertEquals(
                 ParquetDataType.builder().parquetType(REQUIRED_STRING_TYPE).clientDataType(ClientDataType.STRING).build(),

--- a/c3r-sdk-parquet/src/test/java/com/amazonaws/c3r/io/ParquetRowReaderTest.java
+++ b/c3r-sdk-parquet/src/test/java/com/amazonaws/c3r/io/ParquetRowReaderTest.java
@@ -124,7 +124,7 @@ public class ParquetRowReaderTest {
     }
 
     @Test
-    public void getParquetSchemaTest() {
+    public void getParquetSchemaSupportsCryptoComputingTest() {
         final var pReader = new ParquetRowReader(ParquetTestUtility.PARQUET_1_ROW_PRIM_DATA_PATH);
         final var schema = pReader.getParquetSchema();
         ParquetTestUtility.PARQUET_TEST_DATA_TYPES.forEach((header, type) ->
@@ -211,4 +211,5 @@ public class ParquetRowReaderTest {
         writer.close();
         assertThrows(C3rRuntimeException.class, () -> new ParquetRowReader(output.toFile().getAbsolutePath()));
     }
+
 }


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Schema generation modes can take an optional
collaboration ID at the CLI, which the client will 
use to fetch cryptographic computing settings and
appropriately limit/guide schema generation.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.