### PR TITLE
Add filters for gradle-build-ci and jacoco GHAs

### DIFF
--- a/.github/workflows/gradle-build-ci.yml
+++ b/.github/workflows/gradle-build-ci.yml
@@ -13,6 +13,9 @@ permissions:
   contents: read
 
 jobs:
+  # Adds the following filters:
+  # Only run when files that influence the build are updated.
+  # Don't run again if the same commit has already been run.
   filter:
     runs-on: ubuntu-latest
     outputs:
@@ -22,6 +25,7 @@ jobs:
         uses: fkirc/skip-duplicate-actions@v5.3.0
         with:
           concurrent_skipping: 'same_content_newer'
+          paths: '["**/src/**", "**.gradle", "samples/**", "config/**"]'
 
   gradle:
     strategy:

--- a/.github/workflows/jacoco.yml
+++ b/.github/workflows/jacoco.yml
@@ -2,12 +2,27 @@ name: JaCoCo Report
 on: [ pull_request ]
 
 jobs:
+  # Adds the following filters:
+  # Only run when files that influence the build are updated.
+  # Don't run again if the same commit has already been run.
+  filter:
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@v5.3.0
+        with:
+          concurrent_skipping: 'same_content_newer'
+          paths: '["**/src/**", "**.gradle", "samples/**", "config/**"]'
 
   generate-jacoco:
     strategy:
       matrix:
         package: [ 'c3r-sdk-core' , 'c3r-sdk-parquet' , 'c3r-cli' ]
     runs-on: ubuntu-latest
+    needs: filter
+    if: ${{ needs.filter.outputs.should_skip != 'true' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v3


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Added filters for gradle-build-ci and jacoco to only run if changes were made to:
  - any file in any `src` directory
  - any files in the `samples` directory
  - any files in the `config` directory,
  - any `.gradle` files. 
- The file filtering above scales to support new packages automatically instead of just adding exemptions on different file types or stating explicitly which src/gradle files to watch for.
- Added filter for jacoco to skip if it has already run for the same commit.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.