### PR TITLE
Warn on custom null when no cleartext targets

### DIFF
--- a/c3r-sdk-core/build.gradle
+++ b/c3r-sdk-core/build.gradle
@@ -104,6 +104,9 @@ dependencies {
     testImplementation 'org.mockito:mockito-inline:5.1.1'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.2'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.2'
+
+    // Logging test tools
+    testImplementation 'io.github.hakky54:logcaptor:2.8.0'
 }
 
 test {
@@ -195,8 +198,12 @@ task testJar(type: Jar, dependsOn: [classes, testClasses]) {
 
 configurations {
     testArtifacts
+    testImplementation {
+        exclude group: 'org.apache.logging.log4j', module: 'log4j-slf4j-impl'
+        exclude group: 'org.slf4j', module: 'slf4j-reload4j'
+        exclude group: 'org.slf4j', module: 'slf4j-log4j12'
+    }
 }
-
 
 artifacts {
     archives sourcesJar

--- a/c3r-sdk-core/src/test/java/com/amazonaws/c3r/action/CsvRowMarshallerTest.java
+++ b/c3r-sdk-core/src/test/java/com/amazonaws/c3r/action/CsvRowMarshallerTest.java
@@ -4,10 +4,18 @@
 package com.amazonaws.c3r.action;
 
 import com.amazonaws.c3r.config.ClientSettings;
+import com.amazonaws.c3r.config.ColumnHeader;
+import com.amazonaws.c3r.config.ColumnSchema;
+import com.amazonaws.c3r.config.ColumnType;
 import com.amazonaws.c3r.config.EncryptConfig;
+import com.amazonaws.c3r.config.MappedTableSchema;
+import com.amazonaws.c3r.config.Pad;
+import com.amazonaws.c3r.config.TableSchema;
 import com.amazonaws.c3r.exception.C3rIllegalArgumentException;
 import com.amazonaws.c3r.io.FileFormat;
 import com.amazonaws.c3r.utils.GeneralTestUtility;
+import nl.altindag.log.LogCaptor;
+import nl.altindag.log.model.LogEvent;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -15,10 +23,13 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
 
 import static com.amazonaws.c3r.utils.GeneralTestUtility.TEST_CONFIG_DATA_SAMPLE;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class CsvRowMarshallerTest {
     private Path tempDir;
@@ -47,5 +58,26 @@ public class CsvRowMarshallerTest {
                 CsvRowMarshaller.newInstance(configBuilder.fileFormat(FileFormat.PARQUET).build()));
         assertDoesNotThrow(() ->
                 CsvRowMarshaller.newInstance(configBuilder.fileFormat(FileFormat.CSV).build()));
+    }
+
+    @Test
+    public void validateWarnCustomNullsWithNoTargetCleartext() {
+        final List<LogEvent> logEvents;
+        final List<ColumnSchema> columnSchemas = new ArrayList<>();
+        columnSchemas.add(ColumnSchema.builder()
+                .sourceHeader(new ColumnHeader("source"))
+                .targetHeader(new ColumnHeader("target"))
+                .type(ColumnType.SEALED)
+                .pad(Pad.DEFAULT)
+                .build());
+        final TableSchema schema = new MappedTableSchema(columnSchemas);
+        try (LogCaptor logCaptor = LogCaptor.forName("ROOT")) {
+            CsvRowMarshaller.validate("custom null value", schema);
+            logEvents = logCaptor.getLogEvents();
+        }
+        final LogEvent warningEvent = logEvents.get(logEvents.size() - 1); // The last message is the warning
+        final String outputMessage = warningEvent.getFormattedMessage();
+        assertTrue(outputMessage.contains("Received a custom output null value `custom null value`, but no cleartext columns were found. " +
+                "It will be ignored."));
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Add a validation step for the CsvRowMarshaller to give a warning if users have provided a custom null value for the output, but the output has no cleartext columns where the value would be used.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.