### PR TITLE
more detailed max padding description

### DIFF
--- a/c3r-cli/src/main/java/com/amazonaws/c3r/io/schema/InteractiveSchemaGenerator.java
+++ b/c3r-cli/src/main/java/com/amazonaws/c3r/io/schema/InteractiveSchemaGenerator.java
@@ -540,7 +540,9 @@ public final class InteractiveSchemaGenerator {
         } else {
             // padType == PadType.MAX
             defaultLength = 0;
-            basePrompt = "Byte-length beyond max length to pad cleartext to in `" + targetHeader + "`";
+            consoleOutput.println("All values in `" + targetHeader + "` will be padded to the byte-length of the");
+            consoleOutput.println("longest value plus a specified number of additional padding bytes.");
+            basePrompt = "How many additional padding bytes should be used";
         }
 
         final int length = repeatUntilNotNull(() ->


### PR DESCRIPTION
*Issue #, if available:* N/A
*Description of changes:*
Improve max padding description in interactive schema generation.

Old prompt
```
Byte-length beyond max length to pad cleartext to in `COLUMN_NAME` (default `0`)?
```

New prompt
```
All values in `COLUMN_NAME` will be padded to the byte-length of the
longest value plus a specified number of additional padding bytes.
How many additional padding bytes should be used (default `0`)?
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.