### PR TITLE
display messages from AWS SdkExceptions

### DIFF
--- a/c3r-cli/src/main/java/com/amazonaws/c3r/cleanrooms/CleanRoomsDao.java
+++ b/c3r-cli/src/main/java/com/amazonaws/c3r/cleanrooms/CleanRoomsDao.java
@@ -7,9 +7,9 @@ import com.amazonaws.c3r.config.ClientSettings;
 import com.amazonaws.c3r.exception.C3rRuntimeException;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import software.amazon.awssdk.core.exception.SdkException;
 import software.amazon.awssdk.services.cleanrooms.CleanRoomsClient;
 import software.amazon.awssdk.services.cleanrooms.model.AccessDeniedException;
-import software.amazon.awssdk.services.cleanrooms.model.CleanRoomsException;
 import software.amazon.awssdk.services.cleanrooms.model.DataEncryptionMetadata;
 import software.amazon.awssdk.services.cleanrooms.model.GetCollaborationRequest;
 import software.amazon.awssdk.services.cleanrooms.model.GetCollaborationResponse;
@@ -32,9 +32,15 @@ public class CleanRoomsDao {
 
     /**
      * Construct an CleanRoomsDao using the default CleanRoomsClient.
+     *
+     * @throws C3rRuntimeException If a {@link SdkException} is raised connecting to AWS Clean Rooms
      */
     public CleanRoomsDao() {
-        client = CleanRoomsClient.create();
+        try {
+            client = CleanRoomsClient.create();
+        } catch (SdkException e) {
+            throw new C3rRuntimeException("Unable to connect to AWS Clean Rooms: " + e.getMessage(), e);
+        }
     }
 
     /**
@@ -61,7 +67,7 @@ public class CleanRoomsDao {
             throw new C3rRuntimeException(baseError + " Throttling. Please wait a moment before trying again.", e);
         } catch (ValidationException e) {
             throw new C3rRuntimeException(baseError + " CollaborationID could not be validated. " + endError, e);
-        } catch (CleanRoomsException e) {
+        } catch (SdkException e) {
             throw new C3rRuntimeException(baseError + " Unknown error: " + e.getMessage(), e);
         }
         final DataEncryptionMetadata metadata = response.collaboration().dataEncryptionMetadata();

--- a/c3r-cli/src/test/java/com/amazonaws/c3r/cleanrooms/CleanRoomsDaoTest.java
+++ b/c3r-cli/src/test/java/com/amazonaws/c3r/cleanrooms/CleanRoomsDaoTest.java
@@ -6,7 +6,10 @@ package com.amazonaws.c3r.cleanrooms;
 import com.amazonaws.c3r.config.ClientSettings;
 import com.amazonaws.c3r.exception.C3rRuntimeException;
 import com.amazonaws.c3r.utils.GeneralTestUtility;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.core.exception.SdkException;
 import software.amazon.awssdk.services.cleanrooms.CleanRoomsClient;
 import software.amazon.awssdk.services.cleanrooms.model.AccessDeniedException;
 import software.amazon.awssdk.services.cleanrooms.model.CleanRoomsException;
@@ -28,6 +31,31 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class CleanRoomsDaoTest {
+
+    private String oldAwsRegion;
+
+    @BeforeEach
+    public void setup() {
+        oldAwsRegion = System.getProperty("aws.region");
+    }
+
+    @AfterEach
+    public void teardown() {
+        if (oldAwsRegion != null) {
+            System.setProperty("aws.region", oldAwsRegion);
+            oldAwsRegion = null;
+        } else {
+            System.clearProperty("aws.region");
+        }
+    }
+
+    @Test
+    public void constructorTest() throws CleanRoomsException {
+        // Check that the constructor throws an error when AWS_REGION is set to the empty string
+        System.setProperty("aws.region", "");
+        assertThrows(C3rRuntimeException.class, () -> new CleanRoomsDao());
+    }
+
     @Test
     public void getCollaborationDataEncryptionMetadataTest() throws CleanRoomsException {
         final ClientSettings expectedClientSettings = ClientSettings.builder()
@@ -83,7 +111,8 @@ public class CleanRoomsDaoTest {
                 AccessDeniedException.builder().message("AccessDeniedException").build(),
                 ThrottlingException.builder().message("ThrottlingException").build(),
                 ValidationException.builder().message("ValidationException").build(),
-                CleanRoomsException.builder().message("CleanRoomsException").build());
+                CleanRoomsException.builder().message("CleanRoomsException").build(),
+                SdkException.builder().message("SdkException").build());
         for (var exception : exceptions) {
             final var client = mock(CleanRoomsClient.class);
             final var cleanRoomsDaoDao = new CleanRoomsDao(client);


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
Display error message content from AWS SDK exceptions to aid user debugging
since they contain no sensitive information from the input file or schema.

For example, now errors regarding AWS_REGION not being set are printed to the user by default:
```
C3R_SHARED_SECRET="vLO8H9rCFs4FO9b+K9xGERL1IhtgJBhe9OV5EXAMPLE=" \ 
  java -jar c3r-cli/build/libs/c3r-cli-all.jar \
  encrypt \
  samples/csv/data_sample_no_headers.csv \
  --schema=samples/schema/config_sample.json \
  --id=123e4567-e89b-12d3-a456-426614174000 \
  --output=output.csv \
  --overwrite
[ERROR]: An error occurred: Unable to connect to AWS Clean Rooms: Unable to load region from any of the providers in the chain software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain@163d04ff: [software.amazon.awssdk.regions.providers.SystemSettingsRegionProvider@349c1daf: Unable to load region from system settings. Region must be specified either via environment variable (AWS_REGION) or  system property (aws.region)., software.amazon.awssdk.regions.providers.AwsProfileRegionProvider@aafcffa: No region provided in profile: default, software.amazon.awssdk.regions.providers.InstanceProfileRegionProvider@2cae1042: Unable to contact EC2 metadata service.]
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.