### PR TITLE
add param for CleanRoomsDao client creation

### DIFF
--- a/c3r-cli/src/main/java/com/amazonaws/c3r/cleanrooms/CleanRoomsDao.java
+++ b/c3r-cli/src/main/java/com/amazonaws/c3r/cleanrooms/CleanRoomsDao.java
@@ -18,6 +18,7 @@ import software.amazon.awssdk.services.cleanrooms.model.ThrottlingException;
 import software.amazon.awssdk.services.cleanrooms.model.ValidationException;
 
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 /**
  * Create a connection to AWS Clean Rooms to get collaboration information.
@@ -31,13 +32,23 @@ public class CleanRoomsDao {
     private final CleanRoomsClient client;
 
     /**
-     * Construct an CleanRoomsDao using the default CleanRoomsClient.
+     * Construct an CleanRoomsDao using the default {@link CleanRoomsClient}.
      *
      * @throws C3rRuntimeException If a {@link SdkException} is raised connecting to AWS Clean Rooms
      */
     public CleanRoomsDao() {
+        this(CleanRoomsClient::create);
+    }
+
+    /**
+     * Construct a CleanRoomsDao using a specified {@link CleanRoomsClient} supplier.
+     *
+     * @param clientSupplier Supplier for a {@link CleanRoomsClient}.
+     * @throws C3rRuntimeException If a {@link SdkException} is raised connecting to AWS Clean Rooms
+     */
+    CleanRoomsDao(final Supplier<CleanRoomsClient> clientSupplier) {
         try {
-            client = CleanRoomsClient.create();
+            client = clientSupplier.get();
         } catch (SdkException e) {
             throw new C3rRuntimeException("Unable to connect to AWS Clean Rooms: " + e.getMessage(), e);
         }

--- a/c3r-cli/src/test/java/com/amazonaws/c3r/cleanrooms/CleanRoomsDaoTest.java
+++ b/c3r-cli/src/test/java/com/amazonaws/c3r/cleanrooms/CleanRoomsDaoTest.java
@@ -6,9 +6,8 @@ package com.amazonaws.c3r.cleanrooms;
 import com.amazonaws.c3r.config.ClientSettings;
 import com.amazonaws.c3r.exception.C3rRuntimeException;
 import com.amazonaws.c3r.utils.GeneralTestUtility;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.exception.SdkException;
 import software.amazon.awssdk.services.cleanrooms.CleanRoomsClient;
 import software.amazon.awssdk.services.cleanrooms.model.AccessDeniedException;
@@ -22,6 +21,7 @@ import software.amazon.awssdk.services.cleanrooms.model.ThrottlingException;
 import software.amazon.awssdk.services.cleanrooms.model.ValidationException;
 
 import java.util.List;
+import java.util.function.Supplier;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -32,28 +32,12 @@ import static org.mockito.Mockito.when;
 
 public class CleanRoomsDaoTest {
 
-    private String oldAwsRegion;
-
-    @BeforeEach
-    public void setup() {
-        oldAwsRegion = System.getProperty("aws.region");
-    }
-
-    @AfterEach
-    public void teardown() {
-        if (oldAwsRegion != null) {
-            System.setProperty("aws.region", oldAwsRegion);
-            oldAwsRegion = null;
-        } else {
-            System.clearProperty("aws.region");
-        }
-    }
-
     @Test
-    public void constructorTest() throws CleanRoomsException {
-        // Check that the constructor throws an error when AWS_REGION is set to the empty string
-        System.setProperty("aws.region", "");
-        assertThrows(C3rRuntimeException.class, () -> new CleanRoomsDao());
+    public void constructorSdkExceptionTest() throws CleanRoomsException {
+        final Supplier<CleanRoomsClient> faultySupplier = () -> {
+            throw SdkClientException.create("A crazy error occurred connecting to AWS Clean Rooms.");
+        };
+        assertThrows(C3rRuntimeException.class, () -> new CleanRoomsDao(faultySupplier));
     }
 
     @Test


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
Allow custom creation of CleanRoomsClients for CleanRoomsDao objects.
Makes testing in more environments easier, since we can prompt an SDK fail
no matter how hard the SDK tries to find valid settings locally on the system
under test.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.