### PR TITLE
add --profile and --region CLI flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,11 @@ The C3R encryption client is an executable JAR with a command line interface (CL
 
 These modes are briefly described in the subsequent portions of this README.
 
+### C3R with named AWS CLI profiles and regions
+
+Modes which make API calls to AWS services feature optional `--profile` and `--region` flags, allowing for convenient selection of an AWS CLI named profile and AWS region respectively.
+
+
 ### C3R `schema` mode: specifying how data should be encrypted
 
 For the C3R encryption client to encrypt a tabular file for a collaboration, it must have a corresponding schema file specifying how the encrypted output should be derived from the input.
@@ -46,7 +51,7 @@ The C3R encryption client can help generate schema files for an `INPUT` file usi
 $ java -jar c3r-cli.jar schema --interactive INPUT
 ```
 
-See the "Generate an encryption schema for a tabular ﬁle" section of the AWS Clean Rooms documentation for more information.
+See the "Generate an encryption schema for a tabular file" section of the AWS Clean Rooms documentation for more information.
 
 ### C3R `encrypt` mode: encrypting data for a collaboration
 

--- a/c3r-cli/src/main/java/com/amazonaws/c3r/cli/CliDescriptions.java
+++ b/c3r-cli/src/main/java/com/amazonaws/c3r/cli/CliDescriptions.java
@@ -13,6 +13,17 @@ public final class CliDescriptions {
     public static final String VERSION = "1.0.0";
 
     /**
+     * Description of AWS profile.
+     */
+    public static final String AWS_PROFILE_DESCRIPTION = "AWS CLI profile for credentials and config (uses AWS "
+            + " SDK default if omitted)";
+
+    /**
+     * Description of AWS region.
+     */
+    public static final String AWS_REGION_DESCRIPTION = "AWS region for API requests (uses AWS SDK default if omitted)";
+
+    /**
      * Description of how to allow for custom CSV values in the input file.
      */
     public static final String ENCRYPT_CSV_INPUT_NULL_VALUE_DESCRIPTION = "Value representing how NULL is encoded in the input CSV data " +

--- a/c3r-cli/src/test/java/com/amazonaws/c3r/cleanrooms/CleanRoomsDaoTest.java
+++ b/c3r-cli/src/test/java/com/amazonaws/c3r/cleanrooms/CleanRoomsDaoTest.java
@@ -5,10 +5,19 @@ package com.amazonaws.c3r.cleanrooms;
 
 import com.amazonaws.c3r.config.ClientSettings;
 import com.amazonaws.c3r.exception.C3rRuntimeException;
+import com.amazonaws.c3r.utils.FileTestUtility;
 import com.amazonaws.c3r.utils.GeneralTestUtility;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.exception.SdkException;
+import software.amazon.awssdk.profiles.ProfileFileSystemSetting;
+import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.cleanrooms.CleanRoomsClient;
 import software.amazon.awssdk.services.cleanrooms.model.AccessDeniedException;
 import software.amazon.awssdk.services.cleanrooms.model.CleanRoomsException;
@@ -20,24 +29,118 @@ import software.amazon.awssdk.services.cleanrooms.model.ResourceNotFoundExceptio
 import software.amazon.awssdk.services.cleanrooms.model.ThrottlingException;
 import software.amazon.awssdk.services.cleanrooms.model.ValidationException;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
-import java.util.function.Supplier;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 public class CleanRoomsDaoTest {
 
+    private String origAwsRegion;
+
+    private String origAwsAccessKeyId;
+
+    private String origAwsSecretAccessKey;
+
+    private final String testRegion = "not-real-test-region";
+
+    @BeforeEach
+    public void setup() {
+        origAwsRegion = System.getProperty("aws.region");
+        origAwsAccessKeyId = System.getProperty("aws.accessKeyId");
+        origAwsSecretAccessKey = System.getProperty("aws.secretAccessKey");
+
+        System.setProperty("aws.region", testRegion);
+    }
+
+    @AfterEach
+    public void teardown() {
+        if (origAwsRegion != null) {
+            System.setProperty("aws.region", origAwsRegion);
+            origAwsRegion = null;
+        } else {
+            System.clearProperty("aws.region");
+        }
+        if (origAwsAccessKeyId != null) {
+            System.setProperty("aws.accessKeyId", origAwsAccessKeyId);
+            origAwsAccessKeyId = null;
+        } else {
+            System.clearProperty("aws.accessKeyId");
+        }
+        if (origAwsSecretAccessKey != null) {
+            System.setProperty("aws.secretAccessKey", origAwsSecretAccessKey);
+            origAwsSecretAccessKey = null;
+        } else {
+            System.clearProperty("aws.secretAccessKey");
+        }
+    }
+
     @Test
-    public void constructorSdkExceptionTest() throws CleanRoomsException {
-        final Supplier<CleanRoomsClient> faultySupplier = () -> {
-            throw SdkClientException.create("A crazy error occurred connecting to AWS Clean Rooms.");
-        };
-        assertThrows(C3rRuntimeException.class, () -> new CleanRoomsDao(faultySupplier));
+    public void initAwsCredentialsProviderNoProfile() throws CleanRoomsException {
+        final CleanRoomsDao dao = CleanRoomsDao.builder().build();
+        assertInstanceOf(DefaultCredentialsProvider.class, dao.initAwsCredentialsProvider());
+    }
+
+    @Test
+    public void initAwsCredentialsProviderCustomProfile() throws CleanRoomsException, IOException {
+        // We set up a custom temporary config file with a profile `my-profile` and then
+        // have the CleanRoomsDao use that, checking it got all the expected info
+        final String myProfileName = "my-profile";
+        final String myAccessKeyId = "AKIAI44QH8DHBEXAMPLE";
+        final String mySecretAccessKey = "je7MtGbClwBF/2Zp9Utk/h3yCo8nvbEXAMPLEKEY";
+        final String configFileContent = String.join("\n",
+                "[default]",
+                "aws_access_key_id=AKIAIOSFODNN7EXAMPLE",
+                "aws_secret_access_key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+                "",
+                "[profile " + myProfileName + "]",
+                "aws_access_key_id=" + myAccessKeyId,
+                "aws_secret_access_key=" + mySecretAccessKey,
+                ""
+        );
+
+        final Path configFile = FileTestUtility.createTempFile();
+        Files.write(configFile, configFileContent.getBytes(StandardCharsets.UTF_8));
+
+        System.setProperty(ProfileFileSystemSetting.AWS_CONFIG_FILE.property(), configFile.toString());
+        final CleanRoomsDao dao = CleanRoomsDao.builder().profile(myProfileName).build();
+        final AwsCredentialsProvider credentialsProvider = dao.initAwsCredentialsProvider();
+        assertInstanceOf(ProfileCredentialsProvider.class, credentialsProvider);
+        final AwsCredentials credentials = credentialsProvider.resolveCredentials();
+        assertEquals(myAccessKeyId, credentials.accessKeyId());
+        assertEquals(mySecretAccessKey, credentials.secretAccessKey());
+    }
+
+    @Test
+    public void initRegionDefaultRegion() throws CleanRoomsException {
+        final CleanRoomsDao dao = CleanRoomsDao.builder().build();
+        assertEquals(Region.of(testRegion), dao.initRegion());
+    }
+
+    @Test
+    public void initRegionCustomRegion() throws CleanRoomsException {
+        final String customRegion = "us-east-1";
+        final CleanRoomsDao dao = CleanRoomsDao.builder().region(Region.of(customRegion)).build();
+        assertEquals(Region.of(customRegion), dao.initRegion());
+    }
+
+    @Test
+    public void initCleanRoomsClientSdkExceptionTest() throws CleanRoomsException {
+        final CleanRoomsDao dao = mock(CleanRoomsDao.class);
+        when(dao.initRegion()).thenThrow(SdkClientException.create("Region oops!"));
+        when(dao.initAwsCredentialsProvider()).thenThrow(SdkClientException.create("Credentials oops!"));
+        when(dao.getClient()).thenCallRealMethod();
+        assertThrows(C3rRuntimeException.class, () -> dao.getClient());
     }
 
     @Test
@@ -63,8 +166,9 @@ public class CleanRoomsDaoTest {
         final var client = mock(CleanRoomsClient.class);
         when(client.getCollaboration(any(GetCollaborationRequest.class))).thenReturn(response);
 
-        final var cleanRoomsDaoDao = new CleanRoomsDao(client);
-        final var actualClientSettings = cleanRoomsDaoDao.getCollaborationDataEncryptionMetadata(GeneralTestUtility.EXAMPLE_SALT
+        final var dao = spy(CleanRoomsDao.class);
+        when(dao.getClient()).thenReturn(client);
+        final var actualClientSettings = dao.getCollaborationDataEncryptionMetadata(GeneralTestUtility.EXAMPLE_SALT
                 .toString());
         assertEquals(expectedClientSettings, actualClientSettings);
     }
@@ -80,12 +184,13 @@ public class CleanRoomsDaoTest {
         final var client = mock(CleanRoomsClient.class);
         when(client.getCollaboration(any(GetCollaborationRequest.class))).thenReturn(response);
 
-        final var cleanRoomsDaoDao = new CleanRoomsDao(client);
+        final var dao = spy(CleanRoomsDao.class);
+        when(dao.getClient()).thenReturn(client);
         assertThrows(C3rRuntimeException.class, () ->
-                cleanRoomsDaoDao.getCollaborationDataEncryptionMetadata(GeneralTestUtility.EXAMPLE_SALT.toString()));
+                dao.getCollaborationDataEncryptionMetadata(GeneralTestUtility.EXAMPLE_SALT.toString()));
 
         assertThrows(C3rRuntimeException.class, () ->
-                cleanRoomsDaoDao.getCollaborationDataEncryptionMetadata(GeneralTestUtility.EXAMPLE_SALT.toString()));
+                dao.getCollaborationDataEncryptionMetadata(GeneralTestUtility.EXAMPLE_SALT.toString()));
     }
 
     @Test
@@ -99,12 +204,13 @@ public class CleanRoomsDaoTest {
                 SdkException.builder().message("SdkException").build());
         for (var exception : exceptions) {
             final var client = mock(CleanRoomsClient.class);
-            final var cleanRoomsDaoDao = new CleanRoomsDao(client);
             when(client.getCollaboration(any(GetCollaborationRequest.class))).thenThrow(exception);
+            final var dao = spy(CleanRoomsDao.class);
+            when(dao.getClient()).thenReturn(client);
             assertThrows(C3rRuntimeException.class, () ->
-                    cleanRoomsDaoDao.getCollaborationDataEncryptionMetadata(GeneralTestUtility.EXAMPLE_SALT.toString()));
+                    dao.getCollaborationDataEncryptionMetadata(GeneralTestUtility.EXAMPLE_SALT.toString()));
             try {
-                cleanRoomsDaoDao.getCollaborationDataEncryptionMetadata(GeneralTestUtility.EXAMPLE_SALT.toString());
+                dao.getCollaborationDataEncryptionMetadata(GeneralTestUtility.EXAMPLE_SALT.toString());
                 fail();
             } catch (Exception e) {
                 assertEquals(exception, e.getCause());

--- a/c3r-cli/src/test/java/com/amazonaws/c3r/cleanrooms/CleanRoomsDaoTestUtility.java
+++ b/c3r-cli/src/test/java/com/amazonaws/c3r/cleanrooms/CleanRoomsDaoTestUtility.java
@@ -1,0 +1,32 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.amazonaws.c3r.cleanrooms;
+
+import org.mockito.stubbing.Answer;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+public final class CleanRoomsDaoTestUtility {
+
+    /**
+     * Hidden utility class constructor.
+     */
+    private CleanRoomsDaoTestUtility() {
+    }
+
+    public static CleanRoomsDao generateMockDao() {
+        final CleanRoomsDao mockCleanRoomsDao = org.mockito.Mockito.mock(CleanRoomsDao.class);
+        when(mockCleanRoomsDao.withProfile(any())).thenAnswer((Answer<CleanRoomsDao>) (invocation) -> {
+            when(mockCleanRoomsDao.getProfile()).thenReturn(invocation.getArgument(0));
+            return mockCleanRoomsDao;
+        });
+        when(mockCleanRoomsDao.withRegion(any())).thenAnswer((Answer<CleanRoomsDao>) (invocation) -> {
+            when(mockCleanRoomsDao.getRegion()).thenReturn(invocation.getArgument(0));
+            return mockCleanRoomsDao;
+        });
+        when(mockCleanRoomsDao.getRegion()).thenCallRealMethod();
+        return mockCleanRoomsDao;
+    }
+}

--- a/c3r-cli/src/test/java/com/amazonaws/c3r/cli/CliTestUtility.java
+++ b/c3r-cli/src/test/java/com/amazonaws/c3r/cli/CliTestUtility.java
@@ -4,10 +4,10 @@
 package com.amazonaws.c3r.cli;
 
 import com.amazonaws.c3r.cleanrooms.CleanRoomsDao;
+import com.amazonaws.c3r.cleanrooms.CleanRoomsDaoTestUtility;
 import picocli.CommandLine;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
@@ -40,7 +40,7 @@ public final class CliTestUtility {
      */
     public static int runWithoutCleanRooms(final EncryptCliConfigTestUtility args) {
         final CleanRoomsDao cleanRoomsDao;
-        cleanRoomsDao = mock(CleanRoomsDao.class);
+        cleanRoomsDao = CleanRoomsDaoTestUtility.generateMockDao();
         when(cleanRoomsDao.getCollaborationDataEncryptionMetadata(any())).thenReturn(args.getClientSettings());
         return EncryptMode.getApp(cleanRoomsDao).execute(args.toArrayWithoutMode());
     }

--- a/c3r-cli/src/test/java/com/amazonaws/c3r/cli/EncryptCliConfigTestUtility.java
+++ b/c3r-cli/src/test/java/com/amazonaws/c3r/cli/EncryptCliConfigTestUtility.java
@@ -91,6 +91,16 @@ public final class EncryptCliConfigTestUtility {
     private FileFormat fileFormat;
 
     /**
+     * AWS CLI profile.
+     */
+    private String profile;
+
+    /**
+     * AWS region.
+     */
+    private String region;
+
+    /**
      * Hidden default constructor so static instance creators are used.
      */
     private EncryptCliConfigTestUtility() {
@@ -191,6 +201,12 @@ public final class EncryptCliConfigTestUtility {
         }
         if (fileFormat != null) {
             args.add("--fileFormat=" + fileFormat);
+        }
+        if (profile != null) {
+            args.add("--profile=" + profile);
+        }
+        if (region != null) {
+            args.add("--region=" + region);
         }
         return args;
     }

--- a/c3r-cli/src/test/java/com/amazonaws/c3r/cli/EncryptModeArgsTest.java
+++ b/c3r-cli/src/test/java/com/amazonaws/c3r/cli/EncryptModeArgsTest.java
@@ -4,12 +4,16 @@
 package com.amazonaws.c3r.cli;
 
 import com.amazonaws.c3r.cleanrooms.CleanRoomsDao;
+import com.amazonaws.c3r.cleanrooms.CleanRoomsDaoTestUtility;
+import com.amazonaws.c3r.config.ClientSettings;
 import com.amazonaws.c3r.io.FileFormat;
 import com.amazonaws.c3r.utils.FileTestUtility;
 import com.amazonaws.c3r.utils.GeneralTestUtility;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.stubbing.Answer;
 import picocli.CommandLine;
+import software.amazon.awssdk.regions.Region;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -18,8 +22,8 @@ import java.util.function.Function;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class EncryptModeArgsTest {
@@ -31,16 +35,17 @@ public class EncryptModeArgsTest {
 
     private EncryptMode main;
 
-    private CleanRoomsDao cleanRoomsDao;
+    private CleanRoomsDao mockCleanRoomsDao;
 
     @BeforeEach
     public void setup() throws IOException {
         final String output = FileTestUtility.createTempFile().toString();
         encArgs = EncryptCliConfigTestUtility.defaultDryRunTestArgs(INPUT_PATH, SCHEMA_PATH);
         encArgs.setOutput(output);
-        cleanRoomsDao = mock(CleanRoomsDao.class);
-        when(cleanRoomsDao.getCollaborationDataEncryptionMetadata(any())).thenReturn(encArgs.getClientSettings());
-        main = new EncryptMode(cleanRoomsDao);
+        mockCleanRoomsDao = CleanRoomsDaoTestUtility.generateMockDao();
+        when(mockCleanRoomsDao.getCollaborationDataEncryptionMetadata(any()))
+                .thenAnswer((Answer<ClientSettings>) invocation -> encArgs.getClientSettings());
+        main = new EncryptMode(mockCleanRoomsDao);
     }
 
     public int runMainWithCliArgs() {
@@ -109,7 +114,6 @@ public class EncryptModeArgsTest {
     public void allowCleartextFlagTest() {
         checkBooleans(b -> {
             encArgs.setAllowCleartext(b);
-            when(cleanRoomsDao.getCollaborationDataEncryptionMetadata(any())).thenReturn(encArgs.getClientSettings());
             runMainWithCliArgs();
             return main.getClientSettings().isAllowCleartext();
         });
@@ -119,7 +123,6 @@ public class EncryptModeArgsTest {
     public void allowDuplicatesFlagTest() {
         checkBooleans(b -> {
             encArgs.setAllowDuplicates(b);
-            when(cleanRoomsDao.getCollaborationDataEncryptionMetadata(any())).thenReturn(encArgs.getClientSettings());
             runMainWithCliArgs();
             return main.getClientSettings().isAllowDuplicates();
         });
@@ -129,7 +132,6 @@ public class EncryptModeArgsTest {
     public void allowJoinsOnColumnsWithDifferentNamesFlagTest() {
         checkBooleans(b -> {
             encArgs.setAllowJoinsOnColumnsWithDifferentNames(b);
-            when(cleanRoomsDao.getCollaborationDataEncryptionMetadata(any())).thenReturn(encArgs.getClientSettings());
             runMainWithCliArgs();
             return main.getClientSettings().isAllowJoinsOnColumnsWithDifferentNames();
         });
@@ -140,7 +142,6 @@ public class EncryptModeArgsTest {
     public void preserveNullsFlagTest() {
         checkBooleans(b -> {
             encArgs.setPreserveNulls(b);
-            when(cleanRoomsDao.getCollaborationDataEncryptionMetadata(any())).thenReturn(encArgs.getClientSettings());
             runMainWithCliArgs();
             return main.getClientSettings().isPreserveNulls();
         });
@@ -155,4 +156,37 @@ public class EncryptModeArgsTest {
         encArgs.setFileFormat(FileFormat.CSV);
         assertEquals(0, runMainWithCliArgs());
     }
+
+    @Test
+    public void noProfileOrRegionFlagsTest() {
+        main = new EncryptMode(mockCleanRoomsDao);
+        new CommandLine(main).execute(encArgs.toArrayWithoutMode());
+        assertNull(main.getOptionalArgs().getProfile());
+        assertNull(mockCleanRoomsDao.getRegion());
+    }
+
+    @Test
+    public void profileFlagTest() throws IOException {
+        // Ensure that passing a value via the --profile flag is given to the CleanRoomsDao builder's `profile(..)` method.
+        final String myProfileName = "my-profile-name";
+        assertNotEquals(myProfileName, mockCleanRoomsDao.toString());
+
+        when(mockCleanRoomsDao.withRegion(any())).thenThrow(new RuntimeException("test failure - region should have have been set"));
+        encArgs.setProfile(myProfileName);
+        main = new EncryptMode(mockCleanRoomsDao);
+        new CommandLine(main).execute(encArgs.toArrayWithoutMode());
+        assertEquals(myProfileName, main.getOptionalArgs().getProfile());
+        assertEquals(myProfileName, main.getCleanRoomsDao().getProfile());
+    }
+
+    @Test
+    public void regionFlagTest() {
+        final String myRegion = "collywobbles";
+        encArgs.setRegion(myRegion);
+        main = new EncryptMode(mockCleanRoomsDao);
+        new CommandLine(main).execute(encArgs.toArrayWithoutMode());
+        assertEquals(myRegion, main.getOptionalArgs().getRegion());
+        assertEquals(Region.of(myRegion), main.getCleanRoomsDao().getRegion());
+    }
+
 }

--- a/c3r-cli/src/test/java/com/amazonaws/c3r/cli/MainCsvSingleRowRoundTripTest.java
+++ b/c3r-cli/src/test/java/com/amazonaws/c3r/cli/MainCsvSingleRowRoundTripTest.java
@@ -6,6 +6,7 @@ package com.amazonaws.c3r.cli;
 import com.amazonaws.c3r.FingerprintTransformer;
 import com.amazonaws.c3r.SealedTransformer;
 import com.amazonaws.c3r.cleanrooms.CleanRoomsDao;
+import com.amazonaws.c3r.cleanrooms.CleanRoomsDaoTestUtility;
 import com.amazonaws.c3r.config.ColumnHeader;
 import com.amazonaws.c3r.config.ColumnSchema;
 import com.amazonaws.c3r.config.ColumnType;
@@ -34,7 +35,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /*
@@ -134,7 +134,7 @@ public class MainCsvSingleRowRoundTripTest {
             encArgs.setCsvOutputNullValue(encCsvOutputNull);
         }
 
-        final CleanRoomsDao cleanRoomsDao = mock(CleanRoomsDao.class);
+        final CleanRoomsDao cleanRoomsDao = CleanRoomsDaoTestUtility.generateMockDao();
         when(cleanRoomsDao.getCollaborationDataEncryptionMetadata(any())).thenReturn(encArgs.getClientSettings());
         final int exitCode = EncryptMode.getApp(cleanRoomsDao).execute(encArgs.toArrayWithoutMode());
         assertEquals(0, exitCode);

--- a/c3r-cli/src/test/java/com/amazonaws/c3r/cli/MainEnvVarKeyValidTest.java
+++ b/c3r-cli/src/test/java/com/amazonaws/c3r/cli/MainEnvVarKeyValidTest.java
@@ -4,6 +4,7 @@
 package com.amazonaws.c3r.cli;
 
 import com.amazonaws.c3r.cleanrooms.CleanRoomsDao;
+import com.amazonaws.c3r.cleanrooms.CleanRoomsDaoTestUtility;
 import com.amazonaws.c3r.utils.FileTestUtility;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -13,7 +14,6 @@ import java.io.IOException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class MainEnvVarKeyValidTest {
@@ -44,7 +44,7 @@ public class MainEnvVarKeyValidTest {
         final String output = FileTestUtility.createTempFile().toString();
         encArgs = EncryptCliConfigTestUtility.defaultDryRunTestArgs(ENC_INPUT_PATH, SCHEMA_PATH);
         encArgs.setOutput(output);
-        final CleanRoomsDao cleanRoomsDao = mock(CleanRoomsDao.class);
+        final CleanRoomsDao cleanRoomsDao = CleanRoomsDaoTestUtility.generateMockDao();
         when(cleanRoomsDao.getCollaborationDataEncryptionMetadata(any())).thenReturn(encArgs.getClientSettings());
         encMain = EncryptMode.getApp(cleanRoomsDao);
         decArgs = DecryptCliConfigTestUtility.defaultDryRunTestArgs(DEC_INPUT_PATH);

--- a/c3r-cli/src/test/java/com/amazonaws/c3r/cli/MainErrorMessageTest.java
+++ b/c3r-cli/src/test/java/com/amazonaws/c3r/cli/MainErrorMessageTest.java
@@ -4,6 +4,7 @@
 package com.amazonaws.c3r.cli;
 
 import com.amazonaws.c3r.cleanrooms.CleanRoomsDao;
+import com.amazonaws.c3r.cleanrooms.CleanRoomsDaoTestUtility;
 import com.amazonaws.c3r.exception.C3rIllegalArgumentException;
 import com.amazonaws.c3r.exception.C3rRuntimeException;
 import com.amazonaws.c3r.utils.FileTestUtility;
@@ -27,7 +28,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class MainErrorMessageTest {
@@ -60,7 +60,7 @@ public class MainErrorMessageTest {
 
     private void encryptAndCheckErrorMessagePresent(final EncryptCliConfigTestUtility encArgs, final boolean enableStackTraces,
                                                     final String message, final Class<? extends Throwable> expectedException) {
-        final CleanRoomsDao cleanRoomsDao = mock(CleanRoomsDao.class);
+        final CleanRoomsDao cleanRoomsDao = CleanRoomsDaoTestUtility.generateMockDao();
         when(cleanRoomsDao.getCollaborationDataEncryptionMetadata(any())).thenReturn(encArgs.getClientSettings());
         final CommandLine cmd = EncryptMode.getApp(cleanRoomsDao);
         runAndCheckErrorMessagePresent(cmd, encArgs.toArrayWithoutMode(), enableStackTraces, message, expectedException);

--- a/c3r-cli/src/test/java/com/amazonaws/c3r/cli/MainPerfTest.java
+++ b/c3r-cli/src/test/java/com/amazonaws/c3r/cli/MainPerfTest.java
@@ -4,6 +4,7 @@
 package com.amazonaws.c3r.cli;
 
 import com.amazonaws.c3r.cleanrooms.CleanRoomsDao;
+import com.amazonaws.c3r.cleanrooms.CleanRoomsDaoTestUtility;
 import com.amazonaws.c3r.io.CsvTestUtility;
 import com.amazonaws.c3r.utils.FileTestUtility;
 import com.amazonaws.c3r.utils.TableGeneratorTestUtility;
@@ -17,7 +18,6 @@ import java.nio.file.Path;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class MainPerfTest {
@@ -50,7 +50,7 @@ public class MainPerfTest {
         encArgs.setSchema(schemaPath);
         encArgs.setOutput(marshalledPath.toString());
 
-        final CleanRoomsDao cleanRoomsDao = mock(CleanRoomsDao.class);
+        final CleanRoomsDao cleanRoomsDao = CleanRoomsDaoTestUtility.generateMockDao();
         when(cleanRoomsDao.getCollaborationDataEncryptionMetadata(any())).thenReturn(encArgs.getClientSettings());
         long totalMarshalTimeSec = 0;
         for (int i = 0; i < repetitions; i++) {

--- a/c3r-cli/src/test/java/com/amazonaws/c3r/cli/MainTest.java
+++ b/c3r-cli/src/test/java/com/amazonaws/c3r/cli/MainTest.java
@@ -4,6 +4,8 @@
 package com.amazonaws.c3r.cli;
 
 import com.amazonaws.c3r.cleanrooms.CleanRoomsDao;
+import com.amazonaws.c3r.cleanrooms.CleanRoomsDaoTestUtility;
+import com.amazonaws.c3r.config.ClientSettings;
 import com.amazonaws.c3r.io.CsvTestUtility;
 import com.amazonaws.c3r.io.FileFormat;
 import com.amazonaws.c3r.io.ParquetTestUtility;
@@ -12,6 +14,7 @@ import com.amazonaws.c3r.utils.FileUtil;
 import com.amazonaws.c3r.utils.GeneralTestUtility;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.stubbing.Answer;
 import picocli.CommandLine;
 
 import java.io.ByteArrayOutputStream;
@@ -33,7 +36,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class MainTest {
@@ -59,8 +61,9 @@ public class MainTest {
         decArgs = DecryptCliConfigTestUtility.defaultTestArgs();
         decArgs.setFailOnFingerprintColumns(false);
 
-        cleanRoomsDao = mock(CleanRoomsDao.class);
-        when(cleanRoomsDao.getCollaborationDataEncryptionMetadata(any())).thenReturn(encArgs.getClientSettings());
+        cleanRoomsDao = CleanRoomsDaoTestUtility.generateMockDao();
+        when(cleanRoomsDao.getCollaborationDataEncryptionMetadata(any())).thenAnswer((Answer<ClientSettings>) (invocation) ->
+                encArgs.getClientSettings());
     }
 
     // Verify calling the command with no argument fails
@@ -219,7 +222,9 @@ public class MainTest {
         encArgs.setSchema("../samples/schema/config_sample_x3.json");
         encArgs.setPreserveNulls(false);
 
+        final var cleanRoomsDao = CleanRoomsDaoTestUtility.generateMockDao();
         when(cleanRoomsDao.getCollaborationDataEncryptionMetadata(any())).thenReturn(encArgs.getClientSettings());
+
         int exitCode = EncryptMode.getApp(cleanRoomsDao).execute(encArgs.toArrayWithoutMode());
         assertEquals(0, exitCode);
 

--- a/c3r-cli/src/test/java/com/amazonaws/c3r/cli/SchemaCliConfigTestUtility.java
+++ b/c3r-cli/src/test/java/com/amazonaws/c3r/cli/SchemaCliConfigTestUtility.java
@@ -72,6 +72,16 @@ public class SchemaCliConfigTestUtility {
     private String collaborationId;
 
     /**
+     * AWS CLI profile.
+     */
+    private String profile;
+
+    /**
+     * AWS region.
+     */
+    private String region;
+
+    /**
      * Converts the specified command line parameters to a list.
      *
      * @return List of command line parameters
@@ -103,6 +113,12 @@ public class SchemaCliConfigTestUtility {
         }
         if (collaborationId != null) {
             args.add("--id=" + collaborationId);
+        }
+        if (profile != null) {
+            args.add("--profile=" + profile);
+        }
+        if (region != null) {
+            args.add("--region=" + region);
         }
         return args;
     }

--- a/c3r-cli/src/test/java/com/amazonaws/c3r/cli/SchemaModeTest.java
+++ b/c3r-cli/src/test/java/com/amazonaws/c3r/cli/SchemaModeTest.java
@@ -3,7 +3,7 @@
 
 package com.amazonaws.c3r.cli;
 
-import com.amazonaws.c3r.cleanrooms.CleanRoomsDao;
+import com.amazonaws.c3r.cleanrooms.CleanRoomsDaoTestUtility;
 import com.amazonaws.c3r.config.ClientSettings;
 import com.amazonaws.c3r.config.ColumnType;
 import com.amazonaws.c3r.utils.FileTestUtility;
@@ -24,7 +24,6 @@ import java.util.stream.Collectors;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class SchemaModeTest {
@@ -82,7 +81,7 @@ public class SchemaModeTest {
                 .overwrite(true)
                 .collaborationId(GeneralTestUtility.EXAMPLE_SALT.toString())
                 .build();
-        final var cleanRoomsDao = mock(CleanRoomsDao.class);
+        final var cleanRoomsDao = CleanRoomsDaoTestUtility.generateMockDao();
         when(cleanRoomsDao.getCollaborationDataEncryptionMetadata(any())).thenReturn(ClientSettings.lowAssuranceMode());
 
         assertEquals(0, SchemaMode.getApp(cleanRoomsDao).execute(args.toArrayWithoutMode()));
@@ -109,7 +108,7 @@ public class SchemaModeTest {
                 .overwrite(true)
                 .collaborationId(GeneralTestUtility.EXAMPLE_SALT.toString())
                 .build();
-        final var cleanRoomsDao = mock(CleanRoomsDao.class);
+        final var cleanRoomsDao = CleanRoomsDaoTestUtility.generateMockDao();
         when(cleanRoomsDao.getCollaborationDataEncryptionMetadata(any())).thenReturn(ClientSettings.highAssuranceMode());
 
         assertEquals(0, SchemaMode.getApp(cleanRoomsDao).execute(args.toArrayWithoutMode()));
@@ -196,7 +195,7 @@ public class SchemaModeTest {
         final var userInput = new ByteArrayInputStream(inputBuilder.toString().getBytes(StandardCharsets.UTF_8));
         System.setIn(new BufferedInputStream(userInput));
 
-        final var cleanRoomsDao = mock(CleanRoomsDao.class);
+        final var cleanRoomsDao = CleanRoomsDaoTestUtility.generateMockDao();
         when(cleanRoomsDao.getCollaborationDataEncryptionMetadata(any())).thenReturn(ClientSettings.lowAssuranceMode());
 
         assertEquals(0, SchemaMode.getApp(cleanRoomsDao).execute(args.toArrayWithoutMode()));
@@ -245,7 +244,7 @@ public class SchemaModeTest {
         final var userInput = new ByteArrayInputStream(inputBuilder.toString().getBytes(StandardCharsets.UTF_8));
         System.setIn(new BufferedInputStream(userInput));
 
-        final var cleanRoomsDao = mock(CleanRoomsDao.class);
+        final var cleanRoomsDao = CleanRoomsDaoTestUtility.generateMockDao();
         when(cleanRoomsDao.getCollaborationDataEncryptionMetadata(any())).thenReturn(ClientSettings.highAssuranceMode());
 
         assertEquals(0, SchemaMode.getApp(cleanRoomsDao).execute(args.toArrayWithoutMode()));


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add --profile and --region flags to encrypt and schema
modes to support convenient usage of AWS CLI named
profiles and region selection. Also more testing generally
around how our code makes contact with the AWS SDK
for making AWS Clean Rooms API calls.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.