### PR TITLE
Fix CLI arg parsing bugs

### DIFF
--- a/c3r-cli/build.gradle
+++ b/c3r-cli/build.gradle
@@ -104,6 +104,7 @@ dependencies {
 
     // Test infrastructure
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.2'
+    testImplementation 'org.junit.jupiter:junit-jupiter-params:5.9.2'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.2'
 
     // Logging test tools

--- a/c3r-cli/src/main/java/com/amazonaws/c3r/cli/DecryptMode.java
+++ b/c3r-cli/src/main/java/com/amazonaws/c3r/cli/DecryptMode.java
@@ -60,7 +60,7 @@ public class DecryptMode implements Callable<Integer> {
     /**
      * Required values as specified by the user.
      */
-    @CommandLine.ArgGroup(validate = false, heading = "%nRequired parameters:%n")
+    @CommandLine.ArgGroup(multiplicity = "1", exclusive = false, heading = "%nRequired parameters:%n")
     private RequiredArgs requiredArgs = new RequiredArgs();
 
     /**
@@ -132,7 +132,7 @@ public class DecryptMode implements Callable<Integer> {
     /**
      * Optional values as specified by the user.
      */
-    @CommandLine.ArgGroup(validate = false, heading = "%nOptional parameters:%n")
+    @CommandLine.ArgGroup(exclusive = false, heading = "%nOptional parameters:%n")
     private OptionalArgs optionalArgs = new OptionalArgs();
 
     /**

--- a/c3r-cli/src/main/java/com/amazonaws/c3r/cli/EncryptMode.java
+++ b/c3r-cli/src/main/java/com/amazonaws/c3r/cli/EncryptMode.java
@@ -78,7 +78,7 @@ public class EncryptMode implements Callable<Integer> {
     /**
      * Required values as specified by the user.
      */
-    @CommandLine.ArgGroup(validate = false, heading = "%nRequired parameters:%n")
+    @CommandLine.ArgGroup(multiplicity = "1", exclusive = false, heading = "%nRequired parameters:%n")
     private RequiredArgs requiredArgs = new RequiredArgs();
 
     /**
@@ -165,7 +165,7 @@ public class EncryptMode implements Callable<Integer> {
     /**
      * Optional values as specified by the user.
      */
-    @CommandLine.ArgGroup(validate = false, heading = "%nOptional parameters:%n")
+    @CommandLine.ArgGroup(exclusive = false, heading = "%nOptional parameters:%n")
     private OptionalArgs optionalArgs = new OptionalArgs();
 
     /** DAO for interacting with AWS Clean Rooms. */

--- a/c3r-cli/src/main/java/com/amazonaws/c3r/cli/SchemaMode.java
+++ b/c3r-cli/src/main/java/com/amazonaws/c3r/cli/SchemaMode.java
@@ -53,7 +53,7 @@ public class SchemaMode implements Callable<Integer> {
     /**
      * Required values as specified by the user.
      */
-    @CommandLine.ArgGroup(validate = false, heading = "%nRequired parameters:%n")
+    @CommandLine.ArgGroup(multiplicity = "1", heading = "%nRequired parameters:%n")
     private RequiredArgs requiredArgs = new RequiredArgs();
 
     /**
@@ -160,7 +160,7 @@ public class SchemaMode implements Callable<Integer> {
     /**
      * Optional values as specified by the user.
      */
-    @CommandLine.ArgGroup(validate = false, heading = "%nOptional parameters:%n")
+    @CommandLine.ArgGroup(exclusive = false, heading = "%nOptional parameters:%n")
     private OptionalArgs optionalArgs = new OptionalArgs();
 
     /** DAO for interacting with AWS Clean Rooms. */

--- a/c3r-cli/src/test/java/com/amazonaws/c3r/cli/DecryptModeDryRunTest.java
+++ b/c3r-cli/src/test/java/com/amazonaws/c3r/cli/DecryptModeDryRunTest.java
@@ -11,13 +11,11 @@ import org.junit.jupiter.api.Test;
 import picocli.CommandLine;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
-public class DecryptModeArgsTest {
+public class DecryptModeDryRunTest {
     private static final String INPUT_PATH = "../samples/csv/marshalled_data_sample.csv";
 
     private DecryptCliConfigTestUtility decArgs;
@@ -41,22 +39,6 @@ public class DecryptModeArgsTest {
         runMainWithCliArgs();
         assertEquals(INPUT_PATH, main.getRequiredArgs().getInput());
         assertEquals(GeneralTestUtility.EXAMPLE_SALT, main.getRequiredArgs().getId());
-    }
-
-    @Test
-    public void missingRequiredDecryptArgFailsTest() {
-        decArgs.setDryRun(false);
-        decArgs.setEnableStackTraces(false);
-        decArgs.setOverwrite(false);
-        decArgs.setOutput(null);
-        final var origArgs = decArgs.getCliArgsWithoutMode();
-
-        for (int i = 0; i < origArgs.size(); i++) {
-            final List<String> args = new ArrayList<>(origArgs);
-            final String arg = origArgs.get(i);
-            args.remove(arg);
-            assertNotEquals(0, new CommandLine(main).execute(args.toArray(String[]::new)));
-        }
     }
 
     @Test

--- a/c3r-cli/src/test/java/com/amazonaws/c3r/cli/EncryptModeDryRunTest.java
+++ b/c3r-cli/src/test/java/com/amazonaws/c3r/cli/EncryptModeDryRunTest.java
@@ -16,8 +16,6 @@ import picocli.CommandLine;
 import software.amazon.awssdk.regions.Region;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.function.Function;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -26,7 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
-public class EncryptModeArgsTest {
+public class EncryptModeDryRunTest {
     private static final String INPUT_PATH = "../samples/csv/data_sample_without_quotes.csv";
 
     private static final String SCHEMA_PATH = "../samples/schema/config_sample.json";
@@ -58,21 +56,6 @@ public class EncryptModeArgsTest {
         assertEquals(SCHEMA_PATH, main.getRequiredArgs().getSchema());
         assertEquals(INPUT_PATH, main.getRequiredArgs().getInput());
         assertEquals(GeneralTestUtility.EXAMPLE_SALT, main.getRequiredArgs().getId());
-    }
-
-    @Test
-    public void missingRequiredEncryptArgFailsTest() {
-        encArgs.setDryRun(false);
-        encArgs.setEnableStackTraces(false);
-        encArgs.setOverwrite(false);
-        encArgs.setOutput(null);
-        final var origArgs = encArgs.getCliArgsWithoutMode();
-        for (int i = 0; i < origArgs.size(); i++) {
-            final List<String> args = new ArrayList<>(origArgs);
-            final String arg = origArgs.get(i);
-            args.remove(arg);
-            assertNotEquals(0, new CommandLine(main).execute(args.toArray(String[]::new)));
-        }
     }
 
     @Test

--- a/c3r-cli/src/test/java/com/amazonaws/c3r/cli/MainArgParseTest.java
+++ b/c3r-cli/src/test/java/com/amazonaws/c3r/cli/MainArgParseTest.java
@@ -1,0 +1,164 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.amazonaws.c3r.cli;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import picocli.CommandLine;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Class for testing CLI argument parsing from the top-level which intentionally
+ * does not execute any C3R business logic. I.e., only testing CLI parsing
+ * configurations are correct with respect to which arguments are required,
+ * which are exclusive, how certain common behaviors are triggered, etc.
+ */
+public class MainArgParseTest {
+    @Test
+    public void noArgsTest() {
+        final CommandLine.ParseResult result = Main.getApp().parseArgs();
+        assertFalse(result.isVersionHelpRequested());
+        assertFalse(result.isUsageHelpRequested());
+        assertEquals(0, result.subcommands().size());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"-V", "--version"})
+    public void mainVersionTest(final String versionFlag) {
+        final CommandLine.ParseResult result = Main.getApp().parseArgs(versionFlag);
+        assertTrue(result.isVersionHelpRequested());
+        assertFalse(result.isUsageHelpRequested());
+        assertEquals(0, result.subcommands().size());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"-h", "--help"})
+    public void mainHelpTest(final String helpFlag) {
+        final CommandLine.ParseResult result = Main.getApp().parseArgs(helpFlag);
+        assertFalse(result.isVersionHelpRequested());
+        assertTrue(result.isUsageHelpRequested());
+        assertEquals(0, result.subcommands().size());
+    }
+
+    /**
+     * Check help parses as expected for a certain mode.
+     *
+     * @param mode CLI mode
+     * @param help Help flag
+     */
+    private void checkModeHelpFlag(final String mode, final String help) {
+        final CommandLine.ParseResult mainResult = Main.getApp().parseArgs(mode, help);
+        assertEquals(1, mainResult.subcommands().size());
+        final CommandLine.ParseResult modeResult = mainResult.subcommand();
+        assertEquals(mode, modeResult.commandSpec().name());
+        assertEquals(1, modeResult.expandedArgs().size());
+        assertEquals(help, modeResult.expandedArgs().get(0));
+        assertFalse(modeResult.isVersionHelpRequested());
+        assertTrue(modeResult.isUsageHelpRequested());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"encrypt", "decrypt", "schema"})
+    public void modeHelpFlagTest(final String mode) {
+        checkModeHelpFlag(mode, "-h");
+        checkModeHelpFlag(mode, "--help");
+    }
+
+    /**
+     * Check version parses as expected for a certain mode.
+     *
+     * @param mode    CLI mode
+     * @param version Version flag
+     */
+    private void checkModeVersionFlag(final String mode, final String version) {
+        final CommandLine.ParseResult mainResult = Main.getApp().parseArgs(mode, version);
+        assertEquals(1, mainResult.subcommands().size());
+        final CommandLine.ParseResult modeResult = mainResult.subcommand();
+        assertEquals(mode, modeResult.commandSpec().name());
+        assertEquals(1, modeResult.expandedArgs().size());
+        assertEquals(version, modeResult.expandedArgs().get(0));
+        assertTrue(modeResult.isVersionHelpRequested());
+        assertFalse(modeResult.isUsageHelpRequested());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"encrypt", "decrypt", "schema"})
+    public void modeVersionFlagTest(final String mode) {
+        checkModeVersionFlag(mode, "-V");
+        checkModeVersionFlag(mode, "--version");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"encrypt", "decrypt", "schema"})
+    public void subcommandsWithNoArgsTest(final String mode) {
+        // NOTE: This assumes the above listed modes have _some_ required arguments
+        assertThrows(CommandLine.MissingParameterException.class, () -> Main.getApp().parseArgs(mode));
+    }
+
+    @Test
+    public void invalidSubcommandTest() {
+        // NOTE: This assumes the above listed modes have _some_ required arguments
+        assertThrows(CommandLine.UnmatchedArgumentException.class, () -> Main.getApp().parseArgs("not-a-real-mode"));
+    }
+
+    /**
+     * Asserts that no errors occur when using the given minimal args,
+     * and then asserts that removing any of the arguments after the
+     * first (i.e., the mode name itself) raises an error and a missing parameter).
+     *
+     * @param minimalArgs Minimal argument list - first element is mode name, remaining are arguments
+     *                    for that mode.
+     */
+    public void checkMinimalRequiredModeArgs(final String[] minimalArgs) {
+        // NOTE: This assumes the above listed modes have _some_ required arguments
+        assertDoesNotThrow(() -> Main.getApp().parseArgs(minimalArgs));
+
+        // check that for this mode (element 0), removing any argument causes a CLI parse error
+        for (int pos = 1; pos < minimalArgs.length; pos++) {
+            final List<String> invalidParameters = Arrays.stream(minimalArgs).collect(Collectors.toList());
+            invalidParameters.remove(pos);
+            assertThrows(CommandLine.MissingParameterException.class, () ->
+                    Main.getApp().parseArgs(invalidParameters.toArray(String[]::new)));
+        }
+    }
+
+    @Test
+    public void encryptWithRequiredArgs() {
+        final String[] parameters = {"encrypt", "input", "--id=00000000-1111-2222-3333-444444444444", "--schema=schema"};
+        checkMinimalRequiredModeArgs(parameters);
+    }
+
+    @Test
+    public void decryptWithRequiredArgs() {
+        final String[] parameters = {"decrypt", "input", "--id=00000000-1111-2222-3333-444444444444"};
+        checkMinimalRequiredModeArgs(parameters);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"-t", "--template", "-i", "--interactive"})
+    public void schemaWithRequiredArgs(final String modeFlag) {
+        final String[] parameters = {"schema", "input", modeFlag};
+        checkMinimalRequiredModeArgs(parameters);
+    }
+
+    @Test
+    public void schemaGenModesExclusiveArgs() {
+        final String[] parameters = {"schema", "input", "-i", "-t"};
+        // parsing with both -i and -t errors due to those being mutually exclusive
+        assertThrows(CommandLine.MutuallyExclusiveArgsException.class, () -> Main.getApp().parseArgs(parameters));
+        // and simply dropping one fixes things
+        assertDoesNotThrow(() -> Main.getApp().parseArgs(Arrays.copyOfRange(parameters, 0, parameters.length - 1)));
+    }
+
+}

--- a/c3r-cli/src/test/java/com/amazonaws/c3r/cli/SchemaModeDryRunTest.java
+++ b/c3r-cli/src/test/java/com/amazonaws/c3r/cli/SchemaModeDryRunTest.java
@@ -24,8 +24,6 @@ import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -37,7 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
-public class SchemaModeArgsTest {
+public class SchemaModeDryRunTest {
     private static final String INPUT_CSV_PATH = "../samples/csv/data_sample_without_quotes.csv";
 
     private static final String INPUT_PARQUET_PATH = "../samples/parquet/data_sample.parquet";
@@ -96,22 +94,6 @@ public class SchemaModeArgsTest {
         schemaArgs.setOutput("output.json");
         runMainWithCliArgs(true);
         assertEquals("output.json", main.getOptionalArgs().getOutput());
-    }
-
-    @Test
-    public void missingRequiredSchemaModeArgFailsTest() {
-        schemaArgs.setOutput(null);
-        schemaArgs.setOverwrite(false);
-        schemaArgs.setEnableStackTraces(false);
-        main = new SchemaMode(mockCleanRoomsDao);
-        final var origArgs = schemaArgs.toListWithoutMode();
-        for (int i = 0; i < origArgs.size(); i++) {
-            final List<String> args = new ArrayList<>(origArgs);
-            final String arg = origArgs.get(i);
-            args.remove(arg);
-            final int exitCode = new CommandLine(main).execute(args.toArray(String[]::new));
-            assertNotEquals(0, exitCode);
-        }
     }
 
     @Test


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix some minor bugs in optional and required arg parsing.
Rename *ModeArgTest => *ModeDryRunTest to emphasize
those classes check behavior equivalent to running each mode
with the `--dryRun` flag, while the new `MainArgParseTest`
class test only CLI parameter parsing and rules PicoCLI
is being leveraged to enforce.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.