### PR TITLE
drop ignores from copyright checkstyle rule

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -41,7 +41,6 @@
     <!-- Files must contain a copyright header. -->
     <module name="HeaderCheck">
         <property name="headerFile" value="${config_loc}/license-header.txt"/>
-        <property name="ignoreLines" value="2"/>
     </module>
 
     <!-- Enforce maximum line lengths. -->


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The ignore line clause in the copyright checkstyle rule does not apply to our copyright header (i.e., it features no date or other content that changes). Removing this allows checkstyle to validate the whole copyright in each file.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.