### PR TITLE
Revert Gradle version bump to unblock CodeBuild

### DIFF
--- a/.github/workflows/gradle-build-ci.yml
+++ b/.github/workflows/gradle-build-ci.yml
@@ -57,4 +57,4 @@ jobs:
         uses: gradle/gradle-build-action@v2
         with:
           arguments: build
-          gradle-version: 8.0.1
+          gradle-version: 7.5.1

--- a/.github/workflows/jacoco.yml
+++ b/.github/workflows/jacoco.yml
@@ -35,7 +35,7 @@ jobs:
         uses: gradle/gradle-build-action@v2
         with:
           arguments: build
-          gradle-version: 8.0.1
+          gradle-version: 7.5.1
       - name: jacoco-badge-generator
         id: jacoco
         uses: cicirello/jacoco-badge-generator@v2

--- a/c3r-cli/build.gradle
+++ b/c3r-cli/build.gradle
@@ -26,7 +26,7 @@ plugins {
     id 'application'
 
     // Build jumbo jar for distribution
-    id "com.github.johnrengelman.shadow" version "8.1.0"
+    id "com.github.johnrengelman.shadow" version "7.1.2"
 
     // SpotBugs for quality checks and reports of source files. Read more at:
     // https://spotbugs.readthedocs.io/en/stable/gradle.html

--- a/c3r-sdk-core/build.gradle
+++ b/c3r-sdk-core/build.gradle
@@ -174,7 +174,7 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
 }
 
 task testJar(type: Jar, dependsOn: [classes, testClasses]) {
-    archiveClassifier = 'tests'
+    classifier = 'tests'
     from sourceSets.test.output
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Revert bump to gradle 8.0.1 and the shadow package to 8.1.0

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.