### PR TITLE
Validate that CSV column counts are as expected

### DIFF
--- a/c3r-sdk-core/src/main/java/com/amazonaws/c3r/io/CsvRowReader.java
+++ b/c3r-sdk-core/src/main/java/com/amazonaws/c3r/io/CsvRowReader.java
@@ -233,8 +233,8 @@ public final class CsvRowReader extends RowReader<CsvValue> {
     /**
      * Starts iteration style parsing of the CSV file.
      *
-     * @param parser  CSV data parser
-     * @param reader  Source to read CSV data from
+     * @param parser      CSV data parser
+     * @param reader      Source to read CSV data from
      * @param fileCharset Charset for the contents the reader is reading
      * @throws C3rRuntimeException If the file can't be parsed
      */
@@ -322,6 +322,8 @@ public final class CsvRowReader extends RowReader<CsvValue> {
 
     /**
      * Stage the next CSV row.
+     *
+     * @throws C3rRuntimeException If there's a mismatch between the expected column count and the read column count
      */
     protected void refreshNextRow() {
         if (closed) {
@@ -332,6 +334,10 @@ public final class CsvRowReader extends RowReader<CsvValue> {
         if (record == null) {
             nextRow = null;
             return;
+        }
+        if (record.getValues().length != headers.size()) {
+            throw new C3rRuntimeException("Column count mismatch at row " + this.getReadRowCount() + " of input file. Expected "
+                    + headers.size() + " columns, but found " + record.getValues().length + ".");
         }
         nextRow = new CsvRow();
         for (int i = 0; i < headers.size(); i++) {

--- a/c3r-sdk-core/src/test/java/com/amazonaws/c3r/io/CsvRowReaderTest.java
+++ b/c3r-sdk-core/src/test/java/com/amazonaws/c3r/io/CsvRowReaderTest.java
@@ -124,6 +124,18 @@ public class CsvRowReaderTest {
     }
 
     @Test
+    public void tooManyColumnsTest() {
+        assertThrowsExactly(C3rRuntimeException.class,
+                () -> CsvRowReader.builder().sourceName("../samples/csv/one_row_too_many_columns.csv").build());
+    }
+
+    @Test
+    public void tooFewColumnsTest() {
+        assertThrowsExactly(C3rRuntimeException.class,
+                () -> CsvRowReader.builder().sourceName("../samples/csv/one_row_too_few_columns.csv").build());
+    }
+
+    @Test
     public void rowsAreExpectedSizeTest() {
         cReader = CsvRowReader.builder().sourceName("../samples/csv/data_sample_without_quotes.csv").build();
 

--- a/samples/csv/one_row_too_few_columns.csv
+++ b/samples/csv/one_row_too_few_columns.csv
@@ -1,0 +1,2 @@
+FirstName,LastName,Address,City,State,PhoneNumber,Title,Level,Notes
+John,Smith,123 Fake St,Charleston,SC,

--- a/samples/csv/one_row_too_many_columns.csv
+++ b/samples/csv/one_row_too_many_columns.csv
@@ -1,0 +1,2 @@
+FirstName,LastName,Address,City,State,PhoneNumber,Title,Level,Notes
+John,Smith,123 Fake St,Charleston,SC,703-555-1234,CEO,10,,,,,,,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Previously, varying column counts were being permitted for CSVs. Extra columns would be trimmed or missing columns substituted as empty values . But, given the nature of CSVs and not knowing if the additional/missing columns came at the tail of the line or somewhere before, it's prudent to fail and consider it a malformed CSV.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.