### PR TITLE
Add a final warning that files may have been left on disk.

### DIFF
--- a/c3r-cli/src/main/java/com/amazonaws/c3r/cli/Main.java
+++ b/c3r-cli/src/main/java/com/amazonaws/c3r/cli/Main.java
@@ -72,6 +72,7 @@ public final class Main {
             log.error("An unexpected error occurred: {}", e.getClass());
             log.error("Note: the --enableStackTraces flag can provide additional context for errors.");
         }
+        log.warn("Output files may have been left on disk.");
     }
 
     /**


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Adds a final warning message to the user in the event of a terminal error that output files may have been left on disk.

```
19:47:04.223 [Test worker] ERROR com.amazonaws.c3r.cli.Main - An error occurred: Cannot read from file `/tmp/temp10460064972614849108/missingSchemaValidateIllegalArgument.csv`. File does not exist.
com.amazonaws.c3r.exception.C3rIllegalArgumentException: Cannot read from file `/tmp/temp10460064972614849108/missingSchemaValidateIllegalArgument.csv`. File does not exist.
	at com.amazonaws.c3r.utils.FileUtil.verifyReadableFile(FileUtil.java:92)
	at com.amazonaws.c3r.io.schema.SchemaGenerator.validate(SchemaGenerator.java:76)
	at com.amazonaws.c3r.io.schema.SchemaGenerator.<init>(SchemaGenerator.java:65)
	at com.amazonaws.c3r.io.schema.CsvSchemaGenerator.<init>(CsvSchemaGenerator.java:54)
	at com.amazonaws.c3r.io.schema.CsvSchemaGenerator$CsvSchemaGeneratorBuilder.build(CsvSchemaGenerator.java:48)

.
. // abbreviated stack trace
.
	at worker.org.gradle.process.internal.worker.GradleWorkerMain.main(GradleWorkerMain.java:74)
19:47:04.226 [Test worker] WARN com.amazonaws.c3r.cli.Main - Output files may have been left on disk.
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.