### PR TITLE
Publish Javadocs for c3r-sdk-core and c3r-sdk-parquet to Pages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+    ignore:
+      - dependency-name: "io.freefair.javadocs:io.freefair.javadocs.gradle.plugin"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/workflows/javadocs.yml
+++ b/.github/workflows/javadocs.yml
@@ -1,0 +1,65 @@
+# Simple workflow for deploying static content to GitHub Pages
+name: Deploy Javadocs to Pages
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["main"]
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  actions: read
+  contents: read
+  id-token: write
+  pages: write
+
+# Allow one concurrent deployment (if a build is already in progress, cancel in favor of the latest Javadocs)
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  # Only run if the Java files were potentially updated
+  filter:
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@v5.3.0
+        with:
+          # If the Java sources, build files, configuration files or workflows have been updated, we should update the Javadocs.
+          concurrent_skipping: 'same_content_newer'
+          paths: '["**/src/**", "**.gradle", ".github/workflows/javadocs.yml"]'
+  javadocs:
+    # Check for potentially new Javadocs and that we're on the correct repository
+    needs: filter
+    if: ${{ needs.filter.outputs.should_skip != 'true' && github.repository == 'aws/c3r' }}
+    # Set the URL to publish docs to (currently top-level GitHub Page for repo)
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      # Build Javadocs only
+      - name: Set up repository
+        uses: actions/checkout@v3
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'corretto'
+      - name: Build with Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: aggregateJavadoc
+      # Cache Javadocs
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: 'build/docs/aggregateJavadoc/'
+      # Publish Javadocs to URL
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+      - name: Deploy to GitHub Pages
+        uses: actions/deploy-pages@v1

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,36 @@
+/*
+ Applies core Gradle plugins, which are ones built into Gradle itself.
+*/
+buildscript {
+    repositories {
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
+    }
+}
+
+plugins {
+    // Java for compile and unit test of Java source files. Read more at:
+    // https://docs.gradle.org/current/userguide/java_plugin.html
+    id 'java'
+
+    // Aggregate Javadoc generation. Read more at:
+    // https://docs.freefair.io/gradle-plugins/6.6.1/reference/#_io_freefair_javadocs
+    id 'io.freefair.javadocs' version "6.6.3"
+}
+
+apply plugin: "io.freefair.aggregate-javadoc"
+apply plugin: "io.freefair.javadoc-links"
+apply plugin: "io.freefair.javadoc-utf-8"
+
+repositories {
+    // Use Maven Central for resolving dependencies.
+    mavenCentral()
+}
+
+aggregateJavadoc {
+    title("C3R Javadocs SNAPSHOT")
+    options.addStringOption("source", "11")
+    exclude(":c3r-cli")
+    exclude(":c3r-sdk-parquet")
+}

--- a/c3r-cli/build.gradle
+++ b/c3r-cli/build.gradle
@@ -34,7 +34,7 @@ plugins {
 
     // Vanilla code generation. Read more at:
     // https://projectlombok.org/
-    id "io.freefair.lombok" version "6.6.3"
+    id "io.freefair.lombok" version "8.0.1"
 }
 
 // SpotBugs for quality checks and reports of source files. Read more at:

--- a/c3r-cli/build.gradle
+++ b/c3r-cli/build.gradle
@@ -34,11 +34,7 @@ plugins {
 
     // Vanilla code generation. Read more at:
     // https://projectlombok.org/
-    id "io.freefair.lombok" version "8.0.1"
-
-    // Aggregate Javadoc generation. Read more at:
-    // https://docs.freefair.io/gradle-plugins/6.6.1/reference/#_io_freefair_javadocs
-    id 'io.freefair.javadocs' version "8.0.1"
+    id "io.freefair.lombok" version "6.6.3"
 }
 
 // SpotBugs for quality checks and reports of source files. Read more at:
@@ -196,8 +192,4 @@ configurations {
 shadowJar {
     zip64 = true
     mergeServiceFiles()
-}
-
-tasks.withType(Javadoc) {
-    options.addBooleanOption("Xdoclint:-missing", true)
 }

--- a/c3r-sdk-core/build.gradle
+++ b/c3r-sdk-core/build.gradle
@@ -246,7 +246,3 @@ publishing {
 signing {
     sign publishing.publications.maven
 }
-
-tasks.withType(Javadoc) {
-    options.addBooleanOption("Xdoclint:-missing", true)
-}

--- a/c3r-sdk-examples/build.gradle
+++ b/c3r-sdk-examples/build.gradle
@@ -118,7 +118,3 @@ jar {
         attributes('Multi-Release': true)
     }
 }
-
-tasks.withType(Javadoc) {
-    options.addBooleanOption("Xdoclint:-missing", true)
-}

--- a/c3r-sdk-parquet/build.gradle
+++ b/c3r-sdk-parquet/build.gradle
@@ -204,7 +204,3 @@ publishing {
 signing {
     sign publishing.publications.maven
 }
-
-tasks.withType(Javadoc) {
-    options.addBooleanOption("Xdoclint:-missing", true)
-}


### PR DESCRIPTION
*Description of changes:*
Publish the latest Javadocs off of `main` to GitHub pages for `c3r-sdk-core` and `c3r-sdk-parquet`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.