### PR TITLE
refactor: Consolidate versions and gradle builds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,94 @@
+subprojects {
+    /*
+    Applies core Gradle plugins, which are ones built into Gradle itself.
+    */
+    buildscript {
+        repositories {
+            maven {
+                url "https://plugins.gradle.org/m2/"
+            }
+        }
+    }
+
+    repositories {
+        // Use Maven Central for resolving dependencies.
+        mavenCentral()
+    }
+
+    apply plugin: 'java'
+
+    // JaCoCo for coverage metrics and reports of Java source files. Read more at:
+    // https://docs.gradle.org/current/userguide/jacoco_plugin.html
+    apply plugin: 'jacoco'
+
+    // Checkstyle for style checks and reports on Java source files. Read more at:
+    // https://docs.gradle.org/current/userguide/checkstyle_plugin.html
+    apply plugin: 'checkstyle'
+
+    ext.freefair_version = '8.0.1'
+    ext.junit_version = '5.9.2'
+    ext.log4j_version = '2.20.0'
+    ext.mockito_version = '5.2.0'
+
+    dependencies {
+        // Logging
+        implementation "org.apache.logging.log4j:log4j-api:$log4j_version"
+        implementation "org.apache.logging.log4j:log4j-core:$log4j_version"
+        implementation "org.apache.logging.log4j:log4j-slf4j-impl:$log4j_version"
+
+        // Test infrastructure
+        testImplementation "org.junit.jupiter:junit-jupiter-api:$junit_version"
+        testImplementation "org.junit.jupiter:junit-jupiter-params:$junit_version"
+        testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junit_version"
+
+        // Test mocking
+        testImplementation "org.mockito:mockito-core:$mockito_version"
+        testImplementation "org.mockito:mockito-inline:$mockito_version"
+    }
+
+
+    check.dependsOn jacocoTestCoverageVerification
+    jacocoTestCoverageVerification {
+        violationRules {
+            rule {
+                limit {
+                    minimum = 0.85
+                }
+            }
+        }
+    }
+
+    jacocoTestReport {
+        dependsOn test // tests are required to run before generating the report
+        reports {
+            csv.required = true
+            html.required = true
+        }
+    }
+
+    /*
+    Configures the Checkstyle "checkstyle" plugin. Remove this and the plugin if
+    you want to skip these checks and report generation.
+    */
+    checkstyle {
+        sourceSets = [sourceSets.main, sourceSets.test]
+        configFile = file('../config/checkstyle/checkstyle.xml')
+        configProperties.put('checkstyle.suppression.filter', '../config/checkstyle/suppressions.xml')
+        configDirectory.set(file('../config/checkstyle'))
+        ignoreFailures = false
+    }
+
+    tasks.withType(JavaCompile) {
+        options.release = 11
+    }
+
+    tasks.withType(Javadoc) {
+        options.addBooleanOption("Xdoclint:-missing", true)
+    }
+
+    jar {
+        manifest {
+            attributes('Multi-Release': true)
+        }
+    }
+}

--- a/c3r-cli/build.gradle
+++ b/c3r-cli/build.gradle
@@ -1,27 +1,4 @@
-/*
- Applies core Gradle plugins, which are ones built into Gradle itself.
-*/
-buildscript {
-    repositories {
-        maven {
-            url "https://plugins.gradle.org/m2/"
-        }
-    }
-}
-
 plugins {
-    // Java for compile and unit test of Java source files. Read more at:
-    // https://docs.gradle.org/current/userguide/java_plugin.html
-    id 'java'
-
-    // Checkstyle for style checks and reports on Java source files. Read more at:
-    // https://docs.gradle.org/current/userguide/checkstyle_plugin.html
-    id 'checkstyle'
-
-    // JaCoCo for coverage metrics and reports of Java source files. Read more at:
-    // https://docs.gradle.org/current/userguide/jacoco_plugin.html
-    id 'jacoco'
-
     // Support using this application on the CLI
     id 'application'
 
@@ -34,34 +11,17 @@ plugins {
 
     // Vanilla code generation. Read more at:
     // https://projectlombok.org/
-    id "io.freefair.lombok" version "8.0.1"
+    id "io.freefair.lombok" version "$freefair_version"
 
     // Aggregate Javadoc generation. Read more at:
     // https://docs.freefair.io/gradle-plugins/6.6.1/reference/#_io_freefair_javadocs
-    id 'io.freefair.javadocs' version "8.0.1"
+    id 'io.freefair.javadocs' version "$freefair_version"
 }
 
 // SpotBugs for quality checks and reports of source files. Read more at:
 // https://spotbugs.readthedocs.io/en/stable/gradle.html
 apply plugin: 'com.github.spotbugs'
 apply plugin: 'com.github.johnrengelman.shadow'
-
-/*
- Configures the Checkstyle "checkstyle" plugin. Remove this and the plugin if
- you want to skip these checks and report generation.
-*/
-checkstyle {
-    sourceSets = [sourceSets.main, sourceSets.test]
-    configFile = file('../config/checkstyle/checkstyle.xml')
-    configProperties.put('checkstyle.suppression.filter', '../config/checkstyle/suppressions.xml')
-    configDirectory.set(file('../config/checkstyle'))
-    ignoreFailures = false
-}
-
-repositories {
-    // Use Maven Central for resolving dependencies.
-    mavenCentral()
-}
 
 /*
  Configures the SpotBugs "com.github.spotbugs" plugin. Remove this and the
@@ -78,11 +38,6 @@ dependencies {
     implementation project(":c3r-sdk-core")
     implementation project(":c3r-sdk-parquet")
 
-    // Logging
-    implementation 'org.apache.logging.log4j:log4j-api:2.20.0'
-    implementation 'org.apache.logging.log4j:log4j-core:2.20.0'
-    implementation 'org.apache.logging.log4j:log4j-slf4j-impl:2.20.0'
-
     // CLI
     implementation 'info.picocli:picocli:4.7.1'
 
@@ -96,14 +51,6 @@ dependencies {
 
     // Parsing - CSV
     testImplementation 'com.univocity:univocity-parsers:2.9.1'
-
-    // Mocks
-    testImplementation 'org.mockito:mockito-core:5.2.0'
-
-    // Test infrastructure
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.2'
-    testImplementation 'org.junit.jupiter:junit-jupiter-params:5.9.2'
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.2'
 
     // Logging test tools
     testImplementation 'io.github.hakky54:logcaptor:2.9.0'
@@ -156,35 +103,6 @@ tasks.register('badEnvironmentVariableTest', Test) {
 
 check.dependsOn badEnvironmentVariableTest
 
-jacocoTestReport {
-    dependsOn test // tests are required to run before generating the report
-    reports {
-        csv.required = true
-        html.required = true
-    }
-}
-
-check.dependsOn jacocoTestCoverageVerification
-jacocoTestCoverageVerification {
-    violationRules {
-        rule {
-            limit {
-                minimum = 0.85
-            }
-        }
-    }
-}
-
-tasks.withType(JavaCompile) {
-    options.release = 11
-}
-
-jar {
-    manifest {
-        attributes('Multi-Release': true)
-    }
-}
-
 configurations {
     testImplementation {
         exclude group: 'org.apache.logging.log4j', module: 'log4j-slf4j-impl'
@@ -196,8 +114,4 @@ configurations {
 shadowJar {
     zip64 = true
     mergeServiceFiles()
-}
-
-tasks.withType(Javadoc) {
-    options.addBooleanOption("Xdoclint:-missing", true)
 }

--- a/c3r-sdk-core/build.gradle
+++ b/c3r-sdk-core/build.gradle
@@ -1,26 +1,7 @@
-/*
- Applies core Gradle plugins, which are ones built into Gradle itself.
-*/
-buildscript {
-    repositories {
-        maven {
-            url "https://plugins.gradle.org/m2/"
-        }
-    }
-}
-
 plugins {
     // Java compilation, unit tests, and library distribution needs. Read more at:
     // https://docs.gradle.org/current/userguide/java_library_plugin.html
     id 'java-library'
-
-    // Checkstyle for style checks and reports on Java source files. Read more at:
-    // https://docs.gradle.org/current/userguide/checkstyle_plugin.html
-    id 'checkstyle'
-
-    // JaCoCo for coverage metrics and reports of Java source files. Read more at:
-    // https://docs.gradle.org/current/userguide/jacoco_plugin.html
-    id 'jacoco'
 
     // Maven publishing needs
     id 'maven-publish'
@@ -34,27 +15,10 @@ plugins {
 
     // Vanilla code generation. Read more at:
     // https://projectlombok.org/
-    id "io.freefair.lombok" version "8.0.1"
+    id "io.freefair.lombok" version "$freefair_version"
 }
 
 apply plugin: 'com.github.spotbugs'
-
-/*
- Configures the Checkstyle "checkstyle" plugin. Remove this and the plugin if
- you want to skip these checks and report generation.
-*/
-checkstyle {
-    sourceSets = [sourceSets.main, sourceSets.test]
-    configFile = file('../config/checkstyle/checkstyle.xml')
-    configProperties.put('checkstyle.suppression.filter', '../config/checkstyle/suppressions.xml')
-    configDirectory.set(file('../config/checkstyle'))
-    ignoreFailures = false
-}
-
-repositories {
-    // Use Maven Central for resolving dependencies.
-    mavenCentral()
-}
 
 /*
  Configures the SpotBugs "com.github.spotbugs" plugin. Remove this and the
@@ -67,11 +31,6 @@ spotbugs {
 }
 
 dependencies {
-    // Logging
-    implementation 'org.apache.logging.log4j:log4j-api:2.20.0'
-    implementation 'org.apache.logging.log4j:log4j-core:2.20.0'
-    implementation 'org.apache.logging.log4j:log4j-slf4j-impl:2.20.0'
-
     // AWS Clean Rooms
     implementation 'software.amazon.awssdk:cleanrooms:2.20.35'
 
@@ -86,12 +45,6 @@ dependencies {
 
     // https://mvnrepository.com/artifact/com.github.spotbugs/spotbugs-annotations
     implementation 'com.github.spotbugs:spotbugs-annotations:4.7.3'
-
-    // Testing
-    testImplementation 'org.mockito:mockito-core:5.2.0'
-    testImplementation 'org.mockito:mockito-inline:5.2.0'
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.2'
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.2'
 
     // Logging test tools
     testImplementation 'io.github.hakky54:logcaptor:2.9.0'
@@ -138,36 +91,6 @@ tasks.register('checkFileUtilTest', Test) {
 }
 
 check.dependsOn checkFileUtilTest
-
-
-jacocoTestReport {
-    dependsOn test // tests are required to run before generating the report
-    reports {
-        csv.required = true
-        html.required = true
-    }
-}
-
-check.dependsOn jacocoTestCoverageVerification
-jacocoTestCoverageVerification {
-    violationRules {
-        rule {
-            limit {
-                minimum = 0.85
-            }
-        }
-    }
-}
-
-tasks.withType(JavaCompile) {
-    options.release = 11
-}
-
-jar {
-    manifest {
-        attributes('Multi-Release': true)
-    }
-}
 
 task sourcesJar(type: Jar, dependsOn: classes) {
     archiveClassifier = "sources"
@@ -245,8 +168,4 @@ publishing {
 
 signing {
     sign publishing.publications.maven
-}
-
-tasks.withType(Javadoc) {
-    options.addBooleanOption("Xdoclint:-missing", true)
 }

--- a/c3r-sdk-examples/build.gradle
+++ b/c3r-sdk-examples/build.gradle
@@ -1,23 +1,7 @@
-buildscript {
-    repositories {
-        maven {
-            url "https://plugins.gradle.org/m2/"
-        }
-    }
-}
-
 plugins {
     // Java compilation, unit tests, and library distribution needs. Read more at:
     // https://docs.gradle.org/current/userguide/java_library_plugin.html
     id 'java-library'
-
-    // Checkstyle for style checks and reports on Java source files. Read more at:
-    // https://docs.gradle.org/current/userguide/checkstyle_plugin.html
-    id 'checkstyle'
-
-    // JaCoCo for coverage metrics and reports of Java source files. Read more at:
-    // https://docs.gradle.org/current/userguide/jacoco_plugin.html
-    id 'jacoco'
 
     // SpotBugs for quality checks and reports of source files. Read more at:
     // https://spotbugs.readthedocs.io/en/stable/gradle.html
@@ -25,23 +9,6 @@ plugins {
 }
 
 apply plugin: 'com.github.spotbugs'
-
-/*
- Configures the Checkstyle "checkstyle" plugin. Remove this and the plugin if
- you want to skip these checks and report generation.
-*/
-checkstyle {
-    sourceSets = [sourceSets.main, sourceSets.test]
-    configFile = file('../config/checkstyle/checkstyle.xml')
-    configProperties.put('checkstyle.suppression.filter', '../config/checkstyle/suppressions.xml')
-    configDirectory.set(file('../config/checkstyle'))
-    ignoreFailures = false
-}
-
-repositories {
-    // Use Maven Central for resolving dependencies.
-    mavenCentral()
-}
 
 /*
  Configures the SpotBugs "com.github.spotbugs" plugin. Remove this and the
@@ -53,18 +20,17 @@ spotbugs {
     excludeFilter.set(file("../config/spotbugs/excludeFilter.xml"))
 }
 
+ext.spark_version = '3.3.2'
+
 dependencies {
     // AWS-C3R
     implementation project(":c3r-sdk-core")
     implementation project(":c3r-sdk-parquet")
 
     // Spark
-    implementation 'org.apache.spark:spark-core_2.13:3.3.2'
-    implementation 'org.apache.spark:spark-streaming_2.13:3.3.2'
-    implementation 'org.apache.spark:spark-sql_2.13:3.3.2'
-
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.2'
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.2'
+    implementation "org.apache.spark:spark-core_2.13:$spark_version"
+    implementation "org.apache.spark:spark-streaming_2.13:$spark_version"
+    implementation "org.apache.spark:spark-sql_2.13:$spark_version"
 }
 
 test {
@@ -88,37 +54,4 @@ test {
     // Required for Spark. While Spark supports Java 17, it still makes a call to this class
     // and will cause a runtime failure.
     jvmArgs '--add-exports=java.base/sun.nio.ch=ALL-UNNAMED'
-}
-
-jacocoTestReport {
-    dependsOn test // tests are required to run before generating the report
-    reports {
-        csv.required = true
-        html.required = true
-    }
-}
-
-check.dependsOn jacocoTestCoverageVerification
-jacocoTestCoverageVerification {
-    violationRules {
-        rule {
-            limit {
-                minimum = 0.85
-            }
-        }
-    }
-}
-
-tasks.withType(JavaCompile) {
-    options.release = 11
-}
-
-jar {
-    manifest {
-        attributes('Multi-Release': true)
-    }
-}
-
-tasks.withType(Javadoc) {
-    options.addBooleanOption("Xdoclint:-missing", true)
 }

--- a/c3r-sdk-parquet/build.gradle
+++ b/c3r-sdk-parquet/build.gradle
@@ -1,23 +1,7 @@
-buildscript {
-    repositories {
-        maven {
-            url "https://plugins.gradle.org/m2/"
-        }
-    }
-}
-
 plugins {
     // Java compilation, unit tests, and library distribution needs. Read more at:
     // https://docs.gradle.org/current/userguide/java_library_plugin.html
     id 'java-library'
-
-    // Checkstyle for style checks and reports on Java source files. Read more at:
-    // https://docs.gradle.org/current/userguide/checkstyle_plugin.html
-    id 'checkstyle'
-
-    // JaCoCo for coverage metrics and reports of Java source files. Read more at:
-    // https://docs.gradle.org/current/userguide/jacoco_plugin.html
-    id 'jacoco'
 
     // Maven publishing needs
     id 'maven-publish'
@@ -31,27 +15,10 @@ plugins {
 
     // Vanilla code generation. Read more at:
     // https://projectlombok.org/
-    id "io.freefair.lombok" version "8.0.1"
+    id "io.freefair.lombok" version "$freefair_version"
 }
 
 apply plugin: 'com.github.spotbugs'
-
-/*
- Configures the Checkstyle "checkstyle" plugin. Remove this and the plugin if
- you want to skip these checks and report generation.
-*/
-checkstyle {
-    sourceSets = [sourceSets.main, sourceSets.test]
-    configFile = file('../config/checkstyle/checkstyle.xml')
-    configProperties.put('checkstyle.suppression.filter', '../config/checkstyle/suppressions.xml')
-    configDirectory.set(file('../config/checkstyle'))
-    ignoreFailures = false
-}
-
-repositories {
-    // Use Maven Central for resolving dependencies.
-    mavenCentral()
-}
 
 /*
  Configures the SpotBugs "com.github.spotbugs" plugin. Remove this and the
@@ -63,14 +30,11 @@ spotbugs {
     excludeFilter.set(file("../config/spotbugs/excludeFilter.xml"))
 }
 
+ext.hadoop_version = '3.3.5'
+
 dependencies {
     // AWS-C3R
     implementation project(":c3r-sdk-core")
-
-    // Logging
-    implementation 'org.apache.logging.log4j:log4j-api:2.20.0'
-    implementation 'org.apache.logging.log4j:log4j-core:2.20.0'
-    implementation 'org.apache.logging.log4j:log4j-slf4j-impl:2.20.0'
 
     // Parsing - Parquet
     implementation 'org.apache.parquet:parquet-hadoop:1.12.3'
@@ -81,15 +45,9 @@ dependencies {
     //           Classes requiring this dependency:
     //           + org.apache.hadoop.conf.Configuration
     //           + org.apache.hadoop.fs.Path
-    implementation 'org.apache.hadoop:hadoop-common:3.3.5'
-    implementation 'org.apache.hadoop:hadoop-mapreduce-client-core:3.3.5'
+    implementation "org.apache.hadoop:hadoop-common:$hadoop_version"
+    implementation "org.apache.hadoop:hadoop-mapreduce-client-core:$hadoop_version"
 
-    // Testing
-    testImplementation 'org.mockito:mockito-core:5.2.0'
-    testImplementation 'org.mockito:mockito-inline:5.2.0'
-
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.2'
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.2'
     testImplementation project(path: ':c3r-sdk-core', configuration: 'testArtifacts')
 }
 
@@ -112,35 +70,6 @@ test {
     }
 
     finalizedBy jacocoTestReport
-}
-
-jacocoTestReport {
-    dependsOn test // tests are required to run before generating the report
-    reports {
-        csv.required = true
-        html.required = true
-    }
-}
-
-check.dependsOn jacocoTestCoverageVerification
-jacocoTestCoverageVerification {
-    violationRules {
-        rule {
-            limit {
-                minimum = 0.85
-            }
-        }
-    }
-}
-
-tasks.withType(JavaCompile) {
-    options.release = 11
-}
-
-jar {
-    manifest {
-        attributes('Multi-Release': true)
-    }
 }
 
 task sourcesJar(type: Jar, dependsOn: classes) {
@@ -203,8 +132,4 @@ publishing {
 
 signing {
     sign publishing.publications.maven
-}
-
-tasks.withType(Javadoc) {
-    options.addBooleanOption("Xdoclint:-missing", true)
 }


### PR DESCRIPTION
*Issue #, if available:*
- Some of our dependencies need to be kept in sync (hadoop/spark/freefair/etc). Dependabot doesn't update more than one at a time unless the version is parameterized.

*Description of changes:*
- Consolidates `gradle.build` file similarities
- Migrates versions that are coupled to parameters
- Based on behavior mentioned in the comments here: https://github.com/dependabot/dependabot-core/issues/1618

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.