### PR TITLE
ci: link check action for markdown

### DIFF
--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -1,0 +1,18 @@
+name: Check Markdown links
+
+# Run on push, PRs, and every Sunday at 9 am
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: "0 9 * * 0"
+
+jobs:
+  markdown-link-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - uses: gaurav-nelson/github-action-markdown-link-check@v1
+      with:
+        use-quiet-mode: 'yes'
+        use-verbose-mode: 'yes'


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Add a GitHub action (markdown-link-check) to
check links in our markdown still point to valid URLs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.