### PR TITLE
test: Fix test to not overwrite the data it was comparing.

### DIFF
--- a/c3r-sdk-core/src/test/java/com/amazonaws/c3r/config/EncryptConfigTest.java
+++ b/c3r-sdk-core/src/test/java/com/amazonaws/c3r/config/EncryptConfigTest.java
@@ -162,7 +162,7 @@ public class EncryptConfigTest {
 
         final EncryptConfig noHeadersConfig = EncryptConfig.builder()
                 .sourceFile(noHeadersFile)
-                .targetFile(output)
+                .targetFile(FileTestUtility.createTempFile().toString())
                 .tempDir(tempDir)
                 .overwrite(true)
                 .csvInputNullValue(null)
@@ -176,7 +176,7 @@ public class EncryptConfigTest {
 
         final EncryptConfig headersConfig = EncryptConfig.builder()
                 .sourceFile(headersFile)
-                .targetFile(output)
+                .targetFile(FileTestUtility.createTempFile().toString())
                 .tempDir(tempDir)
                 .overwrite(true)
                 .csvInputNullValue(null)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- The test was always comparing the final results against itself by using the same output file and the overwrite flags. This changes it to use different output files.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.