### PR TITLE
refactor: Deprecate config transformers

### DIFF
--- a/c3r-sdk-core/src/main/java/com/amazonaws/c3r/Transformer.java
+++ b/c3r-sdk-core/src/main/java/com/amazonaws/c3r/Transformer.java
@@ -5,6 +5,8 @@ package com.amazonaws.c3r;
 
 import com.amazonaws.c3r.config.ClientSettings;
 import com.amazonaws.c3r.config.ColumnType;
+import com.amazonaws.c3r.config.DecryptConfig;
+import com.amazonaws.c3r.config.EncryptConfig;
 import com.amazonaws.c3r.encryption.EncryptionContext;
 import com.amazonaws.c3r.encryption.Encryptor;
 import com.amazonaws.c3r.encryption.providers.SymmetricStaticProvider;
@@ -113,5 +115,31 @@ public abstract class Transformer {
                 failOnFingerprintColumns));
         transformers.put(ColumnType.SEALED, new SealedTransformer(encryptor, settings));
         return transformers;
+    }
+
+    /**
+     * Create cryptographic transforms available for use.
+     *
+     * @param config The cryptographic settings to use to initialize the transformers
+     * @return Mapping of {@link ColumnType} to the appropriate {@link Transformer}
+     */
+    public static Map<ColumnType, Transformer> initTransformers(final EncryptConfig config) {
+        return initTransformers(config.getSecretKey(),
+                config.getSalt(),
+                config.getSettings(),
+                false); // FailOnFingerprintColumns not relevant to encryption
+    }
+
+    /**
+     * Create cryptographic transforms available for use.
+     *
+     * @param config The cryptographic settings to use to initialize the transformers
+     * @return Mapping of {@link ColumnType} to the appropriate {@link Transformer}
+     */
+    public static Map<ColumnType, Transformer> initTransformers(final DecryptConfig config) {
+        return initTransformers(config.getSecretKey(),
+                config.getSalt(),
+                null, // Settings not relevant to decryption
+                config.isFailOnFingerprintColumns());
     }
 }

--- a/c3r-sdk-core/src/main/java/com/amazonaws/c3r/action/CsvRowMarshaller.java
+++ b/c3r-sdk-core/src/main/java/com/amazonaws/c3r/action/CsvRowMarshaller.java
@@ -61,7 +61,7 @@ public final class CsvRowMarshaller {
                 .outputNullValue(config.getCsvOutputNullValue())
                 .settings(config.getSettings())
                 .schema(config.getTableSchema())
-                .transforms(config.getTransformers())
+                .transforms(Transformer.initTransformers(config))
                 .build();
     }
 

--- a/c3r-sdk-core/src/main/java/com/amazonaws/c3r/action/CsvRowUnmarshaller.java
+++ b/c3r-sdk-core/src/main/java/com/amazonaws/c3r/action/CsvRowUnmarshaller.java
@@ -51,7 +51,7 @@ public final class CsvRowUnmarshaller {
                 .targetFile(config.getTargetFile())
                 .csvInputNullValue(config.getCsvInputNullValue())
                 .csvOutputNullValue(config.getCsvOutputNullValue())
-                .transformers(config.getTransformers())
+                .transformers(Transformer.initTransformers(config))
                 .build();
     }
 

--- a/c3r-sdk-core/src/main/java/com/amazonaws/c3r/config/Config.java
+++ b/c3r-sdk-core/src/main/java/com/amazonaws/c3r/config/Config.java
@@ -3,13 +3,16 @@
 
 package com.amazonaws.c3r.config;
 
+import com.amazonaws.c3r.Transformer;
 import com.amazonaws.c3r.exception.C3rIllegalArgumentException;
 import com.amazonaws.c3r.io.FileFormat;
 import com.amazonaws.c3r.utils.FileUtil;
 import lombok.Getter;
 import lombok.NonNull;
 
+import javax.crypto.SecretKey;
 import java.io.File;
+import java.util.Map;
 
 /**
  * Basic information needed whether encrypting or decrypting data.
@@ -42,23 +45,49 @@ public abstract class Config {
     private final String csvOutputNullValue;
 
     /**
+     * Clean room key used to generate sub-keys for HMAC and encryption.
+     */
+    private final SecretKey secretKey;
+
+    /**
+     * Salt that can be publicly known but adds to randomness of cryptographic operations.
+     */
+    private final String salt;
+
+    /**
+     * Cryptographic transforms available.
+     *
+     * <p>
+     * This method will be deprecated in the next major release. See its replacement at
+     * {@link Transformer#initTransformers(SecretKey, String, ClientSettings, boolean)}
+     */
+    @Deprecated
+    private final Map<ColumnType, Transformer> transformers;
+
+    /**
      * Basic configuration information needed for encrypting or decrypting data.
      *
+     * @param secretKey          Clean room key used to generate sub-keys for HMAC and encryption
      * @param sourceFile         Location of input data
      * @param fileFormat         Format of input data
      * @param targetFile         Where output should be saved
      * @param overwrite          Whether to overwrite the target file if it exists already
      * @param csvInputNullValue  What value should be interpreted as {@code null} for CSV files
      * @param csvOutputNullValue What value should be saved in output to represent {@code null} values for CSV
+     * @param salt               Salt that can be publicly known but adds to randomness of cryptographic operations
+     * @param transformers       The Transformers to use for cryptographic operations
      */
-    protected Config(@NonNull final String sourceFile, final FileFormat fileFormat, final String targetFile, final boolean overwrite,
-                     final String csvInputNullValue, final String csvOutputNullValue) {
+    protected Config(@NonNull final SecretKey secretKey, @NonNull final String sourceFile, final FileFormat fileFormat,
+                     final String targetFile, final boolean overwrite, final String csvInputNullValue, final String csvOutputNullValue,
+                     @NonNull final String salt, @NonNull final Map<ColumnType, Transformer> transformers) {
+        this.secretKey = secretKey;
         this.sourceFile = sourceFile;
         this.fileFormat = fileFormat == null ? FileFormat.fromFileName(sourceFile) : fileFormat;
         this.targetFile = targetFile == null ? getDefaultTargetFile(sourceFile) : targetFile;
         this.csvInputNullValue = csvInputNullValue;
         this.csvOutputNullValue = csvOutputNullValue;
-
+        this.salt = salt;
+        this.transformers = transformers;
         validate(overwrite);
 
         FileUtil.initFileIfNotExists(this.targetFile);

--- a/c3r-sdk-core/src/main/java/com/amazonaws/c3r/config/Config.java
+++ b/c3r-sdk-core/src/main/java/com/amazonaws/c3r/config/Config.java
@@ -3,7 +3,6 @@
 
 package com.amazonaws.c3r.config;
 
-import com.amazonaws.c3r.Transformer;
 import com.amazonaws.c3r.exception.C3rIllegalArgumentException;
 import com.amazonaws.c3r.io.FileFormat;
 import com.amazonaws.c3r.utils.FileUtil;
@@ -12,7 +11,6 @@ import lombok.NonNull;
 
 import javax.crypto.SecretKey;
 import java.io.File;
-import java.util.Map;
 
 /**
  * Basic information needed whether encrypting or decrypting data.
@@ -55,16 +53,6 @@ public abstract class Config {
     private final String salt;
 
     /**
-     * Cryptographic transforms available.
-     *
-     * <p>
-     * This method will be deprecated in the next major release. See its replacement at
-     * {@link Transformer#initTransformers(SecretKey, String, ClientSettings, boolean)}
-     */
-    @Deprecated
-    private final Map<ColumnType, Transformer> transformers;
-
-    /**
      * Basic configuration information needed for encrypting or decrypting data.
      *
      * @param secretKey          Clean room key used to generate sub-keys for HMAC and encryption
@@ -75,11 +63,10 @@ public abstract class Config {
      * @param csvInputNullValue  What value should be interpreted as {@code null} for CSV files
      * @param csvOutputNullValue What value should be saved in output to represent {@code null} values for CSV
      * @param salt               Salt that can be publicly known but adds to randomness of cryptographic operations
-     * @param transformers       The Transformers to use for cryptographic operations
      */
     protected Config(@NonNull final SecretKey secretKey, @NonNull final String sourceFile, final FileFormat fileFormat,
                      final String targetFile, final boolean overwrite, final String csvInputNullValue, final String csvOutputNullValue,
-                     @NonNull final String salt, @NonNull final Map<ColumnType, Transformer> transformers) {
+                     @NonNull final String salt) {
         this.secretKey = secretKey;
         this.sourceFile = sourceFile;
         this.fileFormat = fileFormat == null ? FileFormat.fromFileName(sourceFile) : fileFormat;
@@ -87,7 +74,6 @@ public abstract class Config {
         this.csvInputNullValue = csvInputNullValue;
         this.csvOutputNullValue = csvOutputNullValue;
         this.salt = salt;
-        this.transformers = transformers;
         validate(overwrite);
 
         FileUtil.initFileIfNotExists(this.targetFile);

--- a/c3r-sdk-core/src/main/java/com/amazonaws/c3r/config/DecryptConfig.java
+++ b/c3r-sdk-core/src/main/java/com/amazonaws/c3r/config/DecryptConfig.java
@@ -10,12 +10,23 @@ import lombok.Getter;
 import lombok.NonNull;
 
 import javax.crypto.SecretKey;
+import java.util.Map;
 
 /**
  * Information needed when decrypting a data file.
  */
 @Getter
 public final class DecryptConfig extends Config {
+
+    /**
+     * Cryptographic transforms available.
+     *
+     * <p>
+     * This method will be deprecated in the next major release. See its replacement at
+     * {@link Transformer#initTransformers(SecretKey, String, ClientSettings, boolean)}
+     */
+    @Deprecated
+    private final Map<ColumnType, Transformer> transformers;
 
     /**
      * Whether to throw an error if a Fingerprint column is seen in the data.
@@ -45,8 +56,8 @@ public final class DecryptConfig extends Config {
                           final String csvOutputNullValue,
                           @NonNull final String salt,
                           final boolean failOnFingerprintColumns) {
-        super(secretKey, sourceFile, fileFormat, targetFile, overwrite, csvInputNullValue, csvOutputNullValue, salt,
-                Transformer.initTransformers(secretKey, salt, null, failOnFingerprintColumns));
+        super(secretKey, sourceFile, fileFormat, targetFile, overwrite, csvInputNullValue, csvOutputNullValue, salt);
+        this.transformers = Transformer.initTransformers(secretKey, salt, null, failOnFingerprintColumns);
         this.failOnFingerprintColumns = failOnFingerprintColumns;
     }
 

--- a/c3r-sdk-core/src/main/java/com/amazonaws/c3r/config/DecryptConfig.java
+++ b/c3r-sdk-core/src/main/java/com/amazonaws/c3r/config/DecryptConfig.java
@@ -10,29 +10,29 @@ import lombok.Getter;
 import lombok.NonNull;
 
 import javax.crypto.SecretKey;
-import java.util.Map;
 
 /**
  * Information needed when decrypting a data file.
  */
 @Getter
 public final class DecryptConfig extends Config {
+
     /**
-     * Cryptographic transforms available.
+     * Whether to throw an error if a Fingerprint column is seen in the data.
      */
-    private final Map<ColumnType, Transformer> transformers;
+    private final boolean failOnFingerprintColumns;
 
     /**
      * Set up configuration that will be used for decrypting data.
      *
-     * @param secretKey Clean room key used to generate sub-keys for HMAC and encryption
-     * @param sourceFile Location of input data
-     * @param fileFormat Format of input data
-     * @param targetFile Where output should be saved
-     * @param overwrite Whether to overwrite the target file if it exists already
-     * @param csvInputNullValue What value should be interpreted as {@code null} for CSV files
-     * @param csvOutputNullValue What value should be saved in output to represent {@code null} values for CSV
-     * @param salt Salt that can be publicly known but adds to randomness of cryptographic operations
+     * @param secretKey                Clean room key used to generate sub-keys for HMAC and encryption
+     * @param sourceFile               Location of input data
+     * @param fileFormat               Format of input data
+     * @param targetFile               Where output should be saved
+     * @param overwrite                Whether to overwrite the target file if it exists already
+     * @param csvInputNullValue        What value should be interpreted as {@code null} for CSV files
+     * @param csvOutputNullValue       What value should be saved in output to represent {@code null} values for CSV
+     * @param salt                     Salt that can be publicly known but adds to randomness of cryptographic operations
      * @param failOnFingerprintColumns Whether to throw an error if a Fingerprint column is seen in the data
      */
     @Builder
@@ -45,8 +45,9 @@ public final class DecryptConfig extends Config {
                           final String csvOutputNullValue,
                           @NonNull final String salt,
                           final boolean failOnFingerprintColumns) {
-        super(sourceFile, fileFormat, targetFile, overwrite, csvInputNullValue, csvOutputNullValue);
-        transformers = Transformer.initTransformers(secretKey, salt, null, failOnFingerprintColumns);
+        super(secretKey, sourceFile, fileFormat, targetFile, overwrite, csvInputNullValue, csvOutputNullValue, salt,
+                Transformer.initTransformers(secretKey, salt, null, failOnFingerprintColumns));
+        this.failOnFingerprintColumns = failOnFingerprintColumns;
     }
 
 }

--- a/c3r-sdk-core/src/main/java/com/amazonaws/c3r/config/EncryptConfig.java
+++ b/c3r-sdk-core/src/main/java/com/amazonaws/c3r/config/EncryptConfig.java
@@ -37,24 +37,19 @@ public final class EncryptConfig extends Config {
     private final TableSchema tableSchema;
 
     /**
-     * Cryptographic transforms available.
-     */
-    private final Map<ColumnType, Transformer> transformers;
-
-    /**
      * Set up configuration that will be used for encrypting data.
      *
-     * @param secretKey Clean room key used to generate sub-keys for HMAC and encryption
-     * @param sourceFile Location of input data
-     * @param fileFormat Format of input data
-     * @param targetFile Where output should be saved
-     * @param tempDir Where to write temporary files if needed
-     * @param overwrite Whether to overwrite the target file if it exists already
-     * @param csvInputNullValue What value should be interpreted as {@code null} for CSV files
+     * @param secretKey          Clean room key used to generate sub-keys for HMAC and encryption
+     * @param sourceFile         Location of input data
+     * @param fileFormat         Format of input data
+     * @param targetFile         Where output should be saved
+     * @param tempDir            Where to write temporary files if needed
+     * @param overwrite          Whether to overwrite the target file if it exists already
+     * @param csvInputNullValue  What value should be interpreted as {@code null} for CSV files
      * @param csvOutputNullValue What value should be saved in output to represent {@code null} values for CSV
-     * @param salt Salt that can be publicly known but adds to randomness of cryptographic operations
-     * @param settings Clean room cryptographic settings
-     * @param tableSchema How data in the input file maps to data in the output file
+     * @param salt               Salt that can be publicly known but adds to randomness of cryptographic operations
+     * @param settings           Clean room cryptographic settings
+     * @param tableSchema        How data in the input file maps to data in the output file
      */
     @Builder
     private EncryptConfig(@NonNull final SecretKey secretKey,
@@ -68,11 +63,11 @@ public final class EncryptConfig extends Config {
                           @NonNull final String salt,
                           @NonNull final ClientSettings settings,
                           @NonNull final TableSchema tableSchema) {
-        super(sourceFile, fileFormat, targetFile, overwrite, csvInputNullValue, csvOutputNullValue);
+        super(secretKey, sourceFile, fileFormat, targetFile, overwrite, csvInputNullValue, csvOutputNullValue, salt,
+                Transformer.initTransformers(secretKey, salt, settings, false));
         this.tempDir = tempDir;
         this.settings = settings;
         this.tableSchema = tableSchema;
-        transformers = Transformer.initTransformers(secretKey, salt, settings, false);
         validate();
     }
 

--- a/c3r-sdk-core/src/main/java/com/amazonaws/c3r/config/EncryptConfig.java
+++ b/c3r-sdk-core/src/main/java/com/amazonaws/c3r/config/EncryptConfig.java
@@ -37,6 +37,16 @@ public final class EncryptConfig extends Config {
     private final TableSchema tableSchema;
 
     /**
+     * Cryptographic transforms available.
+     *
+     * <p>
+     * This method will be deprecated in the next major release. See its replacement at
+     * {@link Transformer#initTransformers(SecretKey, String, ClientSettings, boolean)}
+     */
+    @Deprecated
+    private final Map<ColumnType, Transformer> transformers;
+
+    /**
      * Set up configuration that will be used for encrypting data.
      *
      * @param secretKey          Clean room key used to generate sub-keys for HMAC and encryption
@@ -63,11 +73,11 @@ public final class EncryptConfig extends Config {
                           @NonNull final String salt,
                           @NonNull final ClientSettings settings,
                           @NonNull final TableSchema tableSchema) {
-        super(secretKey, sourceFile, fileFormat, targetFile, overwrite, csvInputNullValue, csvOutputNullValue, salt,
-                Transformer.initTransformers(secretKey, salt, settings, false));
+        super(secretKey, sourceFile, fileFormat, targetFile, overwrite, csvInputNullValue, csvOutputNullValue, salt);
         this.tempDir = tempDir;
         this.settings = settings;
         this.tableSchema = tableSchema;
+        this.transformers = Transformer.initTransformers(secretKey, salt, settings, false);
         validate();
     }
 

--- a/c3r-sdk-parquet/src/main/java/com/amazonaws/c3r/action/ParquetRowMarshaller.java
+++ b/c3r-sdk-parquet/src/main/java/com/amazonaws/c3r/action/ParquetRowMarshaller.java
@@ -53,7 +53,7 @@ public final class ParquetRowMarshaller {
                 .settings(config.getSettings())
                 .schema(config.getTableSchema())
                 .tempDir(config.getTempDir())
-                .transforms(config.getTransformers())
+                .transforms(Transformer.initTransformers(config))
                 .build();
     }
 

--- a/c3r-sdk-parquet/src/main/java/com/amazonaws/c3r/action/ParquetRowUnmarshaller.java
+++ b/c3r-sdk-parquet/src/main/java/com/amazonaws/c3r/action/ParquetRowUnmarshaller.java
@@ -47,7 +47,7 @@ public final class ParquetRowUnmarshaller {
         return ParquetRowUnmarshaller.builder()
                 .sourceFile(config.getSourceFile())
                 .targetFile(config.getTargetFile())
-                .transformers(config.getTransformers())
+                .transformers(Transformer.initTransformers(config))
                 .build();
     }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Marks the transformer field in Config classes as deprecated.
- Store the SecretKey and Salt in the Config objects.
- Adds helper methods for `Transformer.initTransformers` that take Config objects.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.