### PR TITLE
ci: Gradle build CI run reduction

### DIFF
--- a/.github/workflows/gradle-build-ci.yml
+++ b/.github/workflows/gradle-build-ci.yml
@@ -6,7 +6,7 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-gradle
 
 name: Run Gradle Build
-on: [push, pull_request]
+on: [pull_request]
 
 permissions:
   actions: read

--- a/.github/workflows/gradle-build-ci.yml
+++ b/.github/workflows/gradle-build-ci.yml
@@ -6,7 +6,10 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-gradle
 
 name: Run Gradle Build
-on: [pull_request]
+on:
+  pull_request:
+  push:
+    branches: main
 
 permissions:
   actions: read


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Reduces Gradle CI to only run on PRs to any branch or pushes to main.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.