### PR TITLE
fix: Change input/output column count limits

### DIFF
--- a/c3r-cli/src/main/java/com/amazonaws/c3r/io/schema/InteractiveSchemaGenerator.java
+++ b/c3r-cli/src/main/java/com/amazonaws/c3r/io/schema/InteractiveSchemaGenerator.java
@@ -618,7 +618,7 @@ public final class InteractiveSchemaGenerator {
                     promptNonNegativeInt(
                             "Number of target columns from source " + columnReference,
                             defaultTargetColumnCount,
-                            Limits.COLUMN_COUNT_MAX));
+                            Limits.ENCRYPTED_OUTPUT_COLUMN_COUNT_MAX));
         } else {
             // This column cannot even appear as cleartext because of collaboration settings,
             // so warn that it will be skipped

--- a/c3r-sdk-core/src/main/java/com/amazonaws/c3r/config/TableSchema.java
+++ b/c3r-sdk-core/src/main/java/com/amazonaws/c3r/config/TableSchema.java
@@ -85,10 +85,10 @@ public abstract class TableSchema implements Validatable {
         if (columns == null || columns.isEmpty()) {
             throw new C3rIllegalArgumentException("At least one data column must provided in the config file.");
         }
-        if (columns.size() > Limits.COLUMN_COUNT_MAX) {
+        if (columns.size() > Limits.ENCRYPTED_OUTPUT_COLUMN_COUNT_MAX) {
             throw new C3rIllegalArgumentException(
-                    "A table can have at most "
-                            + Limits.COLUMN_COUNT_MAX
+                    "An encrypted table can have at most "
+                            + Limits.ENCRYPTED_OUTPUT_COLUMN_COUNT_MAX
                             + " columns "
                             + " but this schema specifies "
                             + getColumns().size()

--- a/c3r-sdk-core/src/main/java/com/amazonaws/c3r/internal/Limits.java
+++ b/c3r-sdk-core/src/main/java/com/amazonaws/c3r/internal/Limits.java
@@ -10,25 +10,9 @@ package com.amazonaws.c3r.internal;
  */
 public final class Limits {
     /**
-     * Max number of columns allowed in a table (2^30).
-     *
-     * <p>
-     * Note: The cryptographic requirements actually limit
-     * the number of encrypted rows to 2^32 and the number
-     * of transfer columns to 2^30, but 2^30 on total
-     * column count both implies those constraints and
-     * is still almost certainly far more than any table
-     * will contain anyway.
-     *
-     * <p>
-     * NOTE: This constraint combined with the limit on the byte size of
-     * output data imply the (infeasible to check) constraint that a single
-     * row must contain less than 2^52 bytes of cleartext.
+     * Max number of columns allowed in an output encrypted table.
      */
-    // Checkstyle treats the 30 as a magic number, but it doesn't make sense in this context to make it a separate variable.
-    // CHECKSTYLE:OFF
-    public static final int COLUMN_COUNT_MAX = 1 << 30;
-    // CHECKSTYLE:ON
+    public static final int ENCRYPTED_OUTPUT_COLUMN_COUNT_MAX = 1600;
 
     /**
      * Max number of encrypted rows across all tables from all providers (2^41).

--- a/c3r-sdk-core/src/main/java/com/amazonaws/c3r/io/CsvRowReader.java
+++ b/c3r-sdk-core/src/main/java/com/amazonaws/c3r/io/CsvRowReader.java
@@ -42,7 +42,7 @@ public final class CsvRowReader extends RowReader<CsvValue> {
      * <p>
      * This is defined at the implementation layer and not the RowReader interface in order to allow tuning among different formats.
      */
-    static final int MAX_COLUMN_COUNT = 1600;
+    static final int MAX_COLUMN_COUNT = 10000;
 
     /**
      * Name of the CSV file for error reporting purposes.

--- a/c3r-sdk-core/src/test/java/com/amazonaws/c3r/config/TableSchemaTest.java
+++ b/c3r-sdk-core/src/test/java/com/amazonaws/c3r/config/TableSchemaTest.java
@@ -64,7 +64,7 @@ public class TableSchemaTest {
         @SuppressWarnings("unchecked")
         final ArrayList<ColumnSchema> fakeBigList = mock(ArrayList.class);
         when(fakeBigList.isEmpty()).thenReturn(false);
-        when(fakeBigList.size()).thenReturn(Limits.COLUMN_COUNT_MAX);
+        when(fakeBigList.size()).thenReturn(Limits.ENCRYPTED_OUTPUT_COLUMN_COUNT_MAX);
 
         // make a fake table schema with the fake column list
 
@@ -72,9 +72,9 @@ public class TableSchemaTest {
         when(maxColumnCountSchema.getColumns()).thenReturn(fakeBigList);
         doCallRealMethod().when(maxColumnCountSchema).validate();
 
-        assertEquals(Limits.COLUMN_COUNT_MAX, maxColumnCountSchema.getColumns().size());
+        assertEquals(Limits.ENCRYPTED_OUTPUT_COLUMN_COUNT_MAX, maxColumnCountSchema.getColumns().size());
 
-        when(fakeBigList.size()).thenReturn(Limits.COLUMN_COUNT_MAX + 1);
+        when(fakeBigList.size()).thenReturn(Limits.ENCRYPTED_OUTPUT_COLUMN_COUNT_MAX + 1);
         assertThrows(C3rIllegalArgumentException.class, maxColumnCountSchema::validate);
     }
 

--- a/c3r-sdk-parquet/src/main/java/com/amazonaws/c3r/io/ParquetRowReader.java
+++ b/c3r-sdk-parquet/src/main/java/com/amazonaws/c3r/io/ParquetRowReader.java
@@ -37,7 +37,7 @@ public final class ParquetRowReader extends RowReader<ParquetValue> {
      * <p>
      * This is defined at the implementation layer and not the RowReader interface in order to allow tuning among different formats.
      */
-    static final int MAX_COLUMN_COUNT = 1600;
+    static final int MAX_COLUMN_COUNT = 10000;
 
     /**
      * Name of input file.

--- a/c3r-sdk-parquet/src/test/java/com/amazonaws/c3r/io/ParquetRowReaderTest.java
+++ b/c3r-sdk-parquet/src/test/java/com/amazonaws/c3r/io/ParquetRowReaderTest.java
@@ -4,11 +4,19 @@
 package com.amazonaws.c3r.io;
 
 import com.amazonaws.c3r.config.ColumnHeader;
-import com.amazonaws.c3r.data.*;
+import com.amazonaws.c3r.data.ParquetDataType;
+import com.amazonaws.c3r.data.ParquetRow;
+import com.amazonaws.c3r.data.ParquetSchema;
+import com.amazonaws.c3r.data.ParquetValue;
+import com.amazonaws.c3r.data.Row;
 import com.amazonaws.c3r.exception.C3rRuntimeException;
 import com.amazonaws.c3r.utils.FileTestUtility;
 import com.amazonaws.c3r.utils.ParquetTestUtility;
-import org.apache.parquet.schema.*;
+import org.apache.parquet.schema.LogicalTypeAnnotation;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.Type;
+import org.apache.parquet.schema.Types;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -18,7 +26,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ParquetRowReaderTest {
 

--- a/c3r-sdk-parquet/src/test/java/com/amazonaws/c3r/io/ParquetRowReaderTest.java
+++ b/c3r-sdk-parquet/src/test/java/com/amazonaws/c3r/io/ParquetRowReaderTest.java
@@ -4,19 +4,11 @@
 package com.amazonaws.c3r.io;
 
 import com.amazonaws.c3r.config.ColumnHeader;
-import com.amazonaws.c3r.data.ParquetDataType;
-import com.amazonaws.c3r.data.ParquetRow;
-import com.amazonaws.c3r.data.ParquetSchema;
-import com.amazonaws.c3r.data.ParquetValue;
-import com.amazonaws.c3r.data.Row;
+import com.amazonaws.c3r.data.*;
 import com.amazonaws.c3r.exception.C3rRuntimeException;
 import com.amazonaws.c3r.utils.FileTestUtility;
 import com.amazonaws.c3r.utils.ParquetTestUtility;
-import org.apache.parquet.schema.LogicalTypeAnnotation;
-import org.apache.parquet.schema.MessageType;
-import org.apache.parquet.schema.PrimitiveType;
-import org.apache.parquet.schema.Type;
-import org.apache.parquet.schema.Types;
+import org.apache.parquet.schema.*;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -26,10 +18,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ParquetRowReaderTest {
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- This changes the input column limit of 1600 to be 10,000.
- The original column limit of 1600 is now enforced on the output instead of the crypto limit of 2^31.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.