### PR TITLE
fix: use Clean Rooms header limits, not Glue

### DIFF
--- a/c3r-cli/src/test/java/com/amazonaws/c3r/io/schema/InteractiveSchemaGeneratorTest.java
+++ b/c3r-cli/src/test/java/com/amazonaws/c3r/io/schema/InteractiveSchemaGeneratorTest.java
@@ -456,7 +456,7 @@ public class InteractiveSchemaGeneratorTest {
         assertFalse(consoleOutput.toString().toLowerCase().contains("expected"));
         assertTrue(consoleOutput.toString().toLowerCase().contains("normalized"));
 
-        createInteractiveSchemaGenerator("b".repeat(Limits.GLUE_MAX_HEADER_UTF8_BYTE_LENGTH) + 1, headers, stringColumnTypes, null);
+        createInteractiveSchemaGenerator("b".repeat(Limits.AWS_CLEAN_ROOMS_HEADER_MAX_LENGTH) + 1, headers, stringColumnTypes, null);
         assertNull(schemaGen.promptTargetHeader(new ColumnHeader("a"), ColumnType.CLEARTEXT));
         assertTrue(consoleOutput.toString().toLowerCase().contains("expected"));
     }
@@ -498,11 +498,11 @@ public class InteractiveSchemaGeneratorTest {
                 schemaGen.promptTargetHeader(new ColumnHeader("a"), ColumnType.FINGERPRINT));
         assertFalse(consoleOutput.toString().toLowerCase().contains("expected"));
 
-        createInteractiveSchemaGenerator("b".repeat(Limits.GLUE_MAX_HEADER_UTF8_BYTE_LENGTH - suffix.length())
+        createInteractiveSchemaGenerator("b".repeat(Limits.AWS_CLEAN_ROOMS_HEADER_MAX_LENGTH - suffix.length())
                 + "\n", headers, stringColumnTypes, null);
         assertEquals(
                 new ColumnHeader(
-                        "b".repeat(Limits.GLUE_MAX_HEADER_UTF8_BYTE_LENGTH - suffix.length())
+                        "b".repeat(Limits.AWS_CLEAN_ROOMS_HEADER_MAX_LENGTH - suffix.length())
                                 + suffix),
                 schemaGen.promptTargetHeader(new ColumnHeader("a"), ColumnType.FINGERPRINT));
         assertFalse(consoleOutput.toString().toLowerCase().contains("expected"));
@@ -510,7 +510,7 @@ public class InteractiveSchemaGeneratorTest {
 
     @Test
     public void promptTargetHeaderCannotAddSuffixTest() {
-        createInteractiveSchemaGenerator("a".repeat(Limits.GLUE_MAX_HEADER_UTF8_BYTE_LENGTH)
+        createInteractiveSchemaGenerator("a".repeat(Limits.AWS_CLEAN_ROOMS_HEADER_MAX_LENGTH)
                 + "\n", headers, stringColumnTypes, null);
         assertNull(schemaGen.promptTargetHeader(new ColumnHeader("a"), ColumnType.FINGERPRINT));
         assertTrue(consoleOutput.toString().toLowerCase().contains("unable to add header suffix"));
@@ -813,7 +813,7 @@ public class InteractiveSchemaGeneratorTest {
                         // header 2, column 1
                         "special", // bad column type
                         "sealed", // header 2, column 1 type
-                        "long_name".repeat(Limits.GLUE_MAX_HEADER_UTF8_BYTE_LENGTH), // header 2, column 1 bad target header
+                        "long_name".repeat(Limits.AWS_CLEAN_ROOMS_HEADER_MAX_LENGTH), // header 2, column 1 bad target header
                         "targetHeader2", // header 2, column 1 target header
                         "maybe", // header 2, column 1 bad use suffix
                         "yes", // header 2, column 1 use suffix
@@ -822,14 +822,14 @@ public class InteractiveSchemaGeneratorTest {
                         // header 2, column 2
                         "goin", // header 2, column 2 bad type
                         "fingerprint", // header 2, column 2 type
-                        "long_name".repeat(Limits.GLUE_MAX_HEADER_UTF8_BYTE_LENGTH), // header 2, column 2 bad target header
+                        "long_name".repeat(Limits.AWS_CLEAN_ROOMS_HEADER_MAX_LENGTH), // header 2, column 2 bad target header
                         "targetHeader2", // header 2, column 2 target header
                         "I can't decide", // header 2, column 2 bad use suffix
                         "yes", // header 2, column 2 use suffix
                         // header 2, column 3
                         "plaintext", // header 2, column 3 bad type
                         "cleartext", // header 2, column 3 type
-                        "long_name".repeat(Limits.GLUE_MAX_HEADER_UTF8_BYTE_LENGTH), // header 2, column 3 bad target header
+                        "long_name".repeat(Limits.AWS_CLEAN_ROOMS_HEADER_MAX_LENGTH), // header 2, column 3 bad target header
                         "targetHeader2", // header 2, column 3 target header
                         // source header3
                         "one", // bad number of columns for header3

--- a/c3r-sdk-core/src/main/java/com/amazonaws/c3r/config/ColumnHeader.java
+++ b/c3r-sdk-core/src/main/java/com/amazonaws/c3r/config/ColumnHeader.java
@@ -9,8 +9,6 @@ import com.amazonaws.c3r.internal.Validatable;
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;
 
-import java.nio.charset.StandardCharsets;
-
 /**
  * Stores a normalized and validated column name (column header).
  */
@@ -127,20 +125,20 @@ public class ColumnHeader implements Validatable {
         if (header == null || header.isBlank()) {
             throw new C3rIllegalArgumentException("Column header names must not be blank");
         }
-        if (header.getBytes(StandardCharsets.UTF_8).length > Limits.GLUE_MAX_HEADER_UTF8_BYTE_LENGTH) {
+        if (header.length() > Limits.AWS_CLEAN_ROOMS_HEADER_MAX_LENGTH) {
             throw new C3rIllegalArgumentException(
                     "Column header names cannot be longer than "
-                            + Limits.GLUE_MAX_HEADER_UTF8_BYTE_LENGTH
-                            + "UTF8 bytes, but found `"
+                            + Limits.AWS_CLEAN_ROOMS_HEADER_MAX_LENGTH
+                            + " characters, but found `"
                             + header
                             + "`.");
         }
-        if (!header.matches(Limits.GLUE_VALID_HEADER_REGEXP)) {
+        if (!Limits.AWS_CLEAN_ROOMS_HEADER_REGEXP.matcher(header).matches()) {
             throw new C3rIllegalArgumentException(
                     "Column header name `"
                             + header
                             + "` does not match pattern `"
-                            + Limits.GLUE_VALID_HEADER_REGEXP
+                            + Limits.AWS_CLEAN_ROOMS_HEADER_REGEXP.pattern()
                             + "`.");
         }
     }

--- a/c3r-sdk-core/src/main/java/com/amazonaws/c3r/internal/Limits.java
+++ b/c3r-sdk-core/src/main/java/com/amazonaws/c3r/internal/Limits.java
@@ -3,6 +3,8 @@
 
 package com.amazonaws.c3r.internal;
 
+import java.util.regex.Pattern;
+
 /**
  * Contains limits required for cryptographic guarantees
  * and other global correctness properties in a single place
@@ -22,21 +24,36 @@ public final class Limits {
     /**
      * Limit on header length (restricted by Glue).
      *
-     * @see <a href="https://docs.aws.amazon.com/glue/latest/dg/aws-glue-api-catalog-tables.html">AWS Glue API Catalog Tables</a>
+     * @deprecated This constant is no longer used - see {@link Limits#AWS_CLEAN_ROOMS_HEADER_MAX_LENGTH} instead.
      */
+    @Deprecated
     public static final int GLUE_MAX_HEADER_UTF8_BYTE_LENGTH = 255;
 
     /**
      * Valid characters used for headers in Glue.
      *
-     * @see <a href="https://docs.aws.amazon.com/glue/latest/dg/aws-glue-api-common.html#aws-glue-api-regex-oneLine">
-     *       AWS Glue API Regex One Line</a>
+     * @deprecated This constant is no longer used - see {@link Limits#AWS_CLEAN_ROOMS_HEADER_REGEXP} instead.
      */
     // Checkstyle doesn't like the escape characters in this string, but it is verbatim from the GLUE docs
     // and so it seems valuable to keep it as-is, so it's a 1-to-1 match.
     // CHECKSTYLE:OFF
     public static final String GLUE_VALID_HEADER_REGEXP = "[\u0020-\uD7FF\uE000-\uFFFD\uD800\uDC00-\uDBFF\uDFFF\t]*";
     // CHECKSTYLE:ON
+
+    /**
+     * Limit on header length (restricted by AWS Clean Rooms).
+     *
+     * @see <a href="https://docs.aws.amazon.com/clean-rooms/latest/apireference/API_Column.html">AWS Clean Rooms API Reference</a>
+     */
+    public static final int AWS_CLEAN_ROOMS_HEADER_MAX_LENGTH = 128;
+
+    /**
+     * Valid pattern for headers an AWS Clean Rooms header.
+     *
+     * @see <a href="https://docs.aws.amazon.com/clean-rooms/latest/apireference/API_Column.html">AWS Clean Rooms API Reference</a>
+     */
+    public static final Pattern AWS_CLEAN_ROOMS_HEADER_REGEXP =
+            Pattern.compile("[a-z0-9_](([a-z0-9_ ]+-)*([a-z0-9_ ]+))?");
 
     /**
      * Hidden utility class constructor.

--- a/c3r-sdk-core/src/test/java/com/amazonaws/c3r/io/CsvRowReaderTest.java
+++ b/c3r-sdk-core/src/test/java/com/amazonaws/c3r/io/CsvRowReaderTest.java
@@ -62,10 +62,10 @@ public class CsvRowReaderTest {
             put("1space", " ");
             put("quoted-blank", "\"\"");
             put("quoted-1space", "\" \"");
-            put("\\N", "\\N");
-            put("quoted-\\N", "\"\\N\"");
-            put("spaced-\\N", " \\N ");
-            put("quoted-spaced-\\N", "\" \\N \"");
+            put("backslash-N", "\\N");
+            put("quoted-backslash-N", "\"\\N\"");
+            put("spaced-backslash-N", " \\N ");
+            put("quoted-spaced-backslash-N", "\" \\N \"");
         }
     };
 
@@ -182,10 +182,10 @@ public class CsvRowReaderTest {
                 "1space", null,
                 "quoted-blank", null,
                 "quoted-1space", " ",
-                "\\N", "\\N",
-                "quoted-\\N", "\\N",
-                "spaced-\\N", "\\N",
-                "quoted-spaced-\\N", " \\N "
+                "backslash-N", "\\N",
+                "quoted-backslash-N", "\\N",
+                "spaced-backslash-N", "\\N",
+                "quoted-spaced-backslash-N", " \\N "
         );
 
         assertEquals(expected, actual);
@@ -204,10 +204,10 @@ public class CsvRowReaderTest {
                 "1space", null,
                 "quoted-blank", "",
                 "quoted-1space", " ",
-                "\\N", "\\N",
-                "quoted-\\N", "\\N",
-                "spaced-\\N", "\\N",
-                "quoted-spaced-\\N", " \\N "
+                "backslash-N", "\\N",
+                "quoted-backslash-N", "\\N",
+                "spaced-backslash-N", "\\N",
+                "quoted-spaced-backslash-N", " \\N "
         );
 
         assertEquals(expected, actual);
@@ -224,10 +224,10 @@ public class CsvRowReaderTest {
                 "1space", null,
                 "quoted-blank", "",
                 "quoted-1space", " ",
-                "\\N", "\\N",
-                "quoted-\\N", "\\N",
-                "spaced-\\N", "\\N",
-                "quoted-spaced-\\N", " \\N "
+                "backslash-N", "\\N",
+                "quoted-backslash-N", "\\N",
+                "spaced-backslash-N", "\\N",
+                "quoted-spaced-backslash-N", " \\N "
         );
 
         assertEquals(expected, actual);
@@ -244,10 +244,10 @@ public class CsvRowReaderTest {
                 "1space", "",
                 "quoted-blank", null,
                 "quoted-1space", " ",
-                "\\N", "\\N",
-                "quoted-\\N", "\\N",
-                "spaced-\\N", "\\N",
-                "quoted-spaced-\\N", " \\N "
+                "backslash-N", "\\N",
+                "quoted-backslash-N", "\\N",
+                "spaced-backslash-N", "\\N",
+                "quoted-spaced-backslash-N", " \\N "
         );
 
         assertEquals(expected, actual);
@@ -263,10 +263,10 @@ public class CsvRowReaderTest {
                 "1space", "",
                 "quoted-blank", "",
                 "quoted-1space", " ",
-                "\\N", "\\N",
-                "quoted-\\N", "\\N",
-                "spaced-\\N", "\\N",
-                "quoted-spaced-\\N", " \\N "
+                "backslash-N", "\\N",
+                "quoted-backslash-N", "\\N",
+                "spaced-backslash-N", "\\N",
+                "quoted-spaced-backslash-N", " \\N "
         );
 
         assertEquals(expected, actual);
@@ -282,10 +282,10 @@ public class CsvRowReaderTest {
                 "1space", "",
                 "quoted-blank", "",
                 "quoted-1space", " ",
-                "\\N", null,
-                "quoted-\\N", null,
-                "spaced-\\N", null,
-                "quoted-spaced-\\N", " \\N "
+                "backslash-N", null,
+                "quoted-backslash-N", null,
+                "spaced-backslash-N", null,
+                "quoted-spaced-backslash-N", " \\N "
         );
 
         assertEquals(expected, actual);
@@ -306,7 +306,7 @@ public class CsvRowReaderTest {
     @Test
     public void maxVarcharByteCountHeaderTest() throws IOException {
         final Map<String, String> columns = new HashMap<>();
-        final byte[] varcharBytes = new byte[Limits.GLUE_MAX_HEADER_UTF8_BYTE_LENGTH + 1];
+        final byte[] varcharBytes = new byte[Limits.AWS_CLEAN_ROOMS_HEADER_MAX_LENGTH + 1];
         Arrays.fill(varcharBytes, (byte) 'a');
         final String oversizedVarchar = new String(varcharBytes, StandardCharsets.UTF_8);
         columns.put(oversizedVarchar, "value");
@@ -329,7 +329,7 @@ public class CsvRowReaderTest {
                 "\"\",\"\",\"\",\"\",\"\",\"\"",
                 "\",\",\",\",\",\",\",\",\",\",\",\"",
                 ",,,,,\n",
-                "a".repeat(Limits.GLUE_MAX_HEADER_UTF8_BYTE_LENGTH + 1) + ",,,,,"
+                "a".repeat(Limits.AWS_CLEAN_ROOMS_HEADER_MAX_LENGTH + 1) + ",,,,,"
         );
         for (var content : fileContentWith6Columns) {
             final Path nullsCsv = FileTestUtility.createTempFile();

--- a/c3r-sdk-core/src/test/java/com/amazonaws/c3r/io/sql/TableGeneratorTest.java
+++ b/c3r-sdk-core/src/test/java/com/amazonaws/c3r/io/sql/TableGeneratorTest.java
@@ -130,7 +130,7 @@ public class TableGeneratorTest {
 
     @Test
     public void initTableTargetColumnHeaderBadSqlHeaderTest() {
-        final char[] sqlHeaderTooLong = new char[Limits.GLUE_MAX_HEADER_UTF8_BYTE_LENGTH];
+        final char[] sqlHeaderTooLong = new char[Limits.AWS_CLEAN_ROOMS_HEADER_MAX_LENGTH];
         Arrays.fill(sqlHeaderTooLong, 'a');
 
         final List<ColumnSchema> columnSchemas = new ArrayList<>();


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
+ Deprecate Glue header limits
+ Use Clean Rooms header limits
+ Precompile the regexp expression for efficient matching
+ Change single-row test headers to not include a backslash (violates new restrictions)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.