### PR TITLE
feat(decrypt): skipHeaderNormalization for decrypt modes

### DIFF
--- a/c3r-cli-spark/src/main/java/com/amazonaws/c3r/spark/cli/DecryptMode.java
+++ b/c3r-cli-spark/src/main/java/com/amazonaws/c3r/spark/cli/DecryptMode.java
@@ -227,12 +227,16 @@ public class DecryptMode implements Callable<Integer> {
                         final Dataset<Row> csvDataset = SparkCsvReader.readInput(sparkSession,
                                 cfg.getSourceFile(),
                                 cfg.getCsvInputNullValue(),
-                                null);
+                                /* externalHeaders */ null,
+                                /* skipHeaderNormalization */ true);
                         final Dataset<Row> unmarshalledCsvDataset = SparkUnmarshaller.decrypt(csvDataset, cfg);
                         SparkCsvWriter.writeOutput(unmarshalledCsvDataset, cfg.getTargetFile(), cfg.getCsvOutputNullValue());
                         break;
                     case PARQUET:
-                        final Dataset<Row> parquetDataset = SparkParquetReader.readInput(sparkSession, cfg.getSourceFile());
+                        final Dataset<Row> parquetDataset = SparkParquetReader.readInput(
+                                sparkSession,
+                                cfg.getSourceFile(),
+                                /* skipHeaderNormalization */ true);
                         final Dataset<Row> unmarshalledParquetDataset = SparkUnmarshaller.decrypt(parquetDataset, cfg);
                         SparkParquetWriter.writeOutput(unmarshalledParquetDataset, cfg.getTargetFile());
                         break;

--- a/c3r-cli-spark/src/main/java/com/amazonaws/c3r/spark/cli/EncryptMode.java
+++ b/c3r-cli-spark/src/main/java/com/amazonaws/c3r/spark/cli/EncryptMode.java
@@ -340,7 +340,10 @@ public class EncryptMode implements Callable<Integer> {
                         SparkCsvWriter.writeOutput(marshalledCsvDataset, cfg.getTargetFile(), cfg.getCsvOutputNullValue());
                         break;
                     case PARQUET:
-                        final Dataset<Row> parquetDataset = SparkParquetReader.readInput(sparkSession, cfg.getSourceFile());
+                        final Dataset<Row> parquetDataset = SparkParquetReader.readInput(
+                                sparkSession,
+                                cfg.getSourceFile(),
+                                /* skipHeaderNormalization */ false);
                         final Dataset<Row> marshalledParquetDataset = SparkMarshaller.encrypt(parquetDataset, cfg);
                         SparkParquetWriter.writeOutput(marshalledParquetDataset, cfg.getTargetFile());
                         break;

--- a/c3r-cli-spark/src/main/java/com/amazonaws/c3r/spark/config/SparkConfig.java
+++ b/c3r-cli-spark/src/main/java/com/amazonaws/c3r/spark/config/SparkConfig.java
@@ -16,6 +16,13 @@ import java.nio.file.Path;
  * Basic information needed whether encrypting or decrypting data for Spark types.
  */
 public class SparkConfig extends Config {
+
+    /**
+     * {@link org.apache.spark.sql.util.CaseInsensitiveStringMap} key for whether header normalization
+     * is skipped.
+     */
+    public static final String PROPERTY_KEY_SKIP_HEADER_NORMALIZATION = "skipHeaderNormalization";
+
     /**
      * Basic configuration information needed for encrypting or decrypting data.
      *

--- a/c3r-cli-spark/src/main/java/com/amazonaws/c3r/spark/io/schema/SchemaGeneratorUtils.java
+++ b/c3r-cli-spark/src/main/java/com/amazonaws/c3r/spark/io/schema/SchemaGeneratorUtils.java
@@ -26,7 +26,7 @@ public final class SchemaGeneratorUtils {
         if (columnHeader != null) {
             return "column `" + columnHeader + "`";
         } else {
-            return ColumnHeader.getColumnHeaderFromIndex(columnIndex).toString();
+            return ColumnHeader.of(columnIndex).toString();
         }
     }
 

--- a/c3r-cli-spark/src/main/java/com/amazonaws/c3r/spark/io/schema/TemplateSchemaGenerator.java
+++ b/c3r-cli-spark/src/main/java/com/amazonaws/c3r/spark/io/schema/TemplateSchemaGenerator.java
@@ -173,7 +173,7 @@ public final class TemplateSchemaGenerator {
             final var entryArray = new JsonArray(1);
             // template entry
             final var templateEntry = new JsonObject();
-            templateEntry.addProperty("targetHeader", ColumnHeader.getColumnHeaderFromIndex(i).toString());
+            templateEntry.addProperty("targetHeader", ColumnHeader.of(i).toString());
             if (sourceColumnTypes.get(i).supportsCryptographicComputing()) {
                 templateEntry.addProperty("type", columnTypeOptions);
                 templateEntry.add("pad", EXAMPLE_PAD);

--- a/c3r-cli-spark/src/test/java/com/amazonaws/c3r/spark/action/SparkMarshallerTest.java
+++ b/c3r-cli-spark/src/test/java/com/amazonaws/c3r/spark/action/SparkMarshallerTest.java
@@ -315,7 +315,7 @@ public class SparkMarshallerTest {
     @Test
     public void marshalDataParquetEncryptedMixedTypesTest() {
         final Dataset<Row> mixedDataset = SparkParquetReader
-                .readInput(session, "../samples/parquet/data_sample_with_non_string_types.parquet");
+                .readInput(session, "../samples/parquet/data_sample_with_non_string_types.parquet", /* skipHeaderNormalization */ false);
         // assert there is indeed a non-String type
         assertTrue(mixedDataset.schema().toList().filter(struct -> struct.dataType() != DataTypes.StringType).size() > 0);
 

--- a/c3r-cli-spark/src/test/java/com/amazonaws/c3r/spark/action/SparkUnmarshallerTest.java
+++ b/c3r-cli-spark/src/test/java/com/amazonaws/c3r/spark/action/SparkUnmarshallerTest.java
@@ -80,7 +80,8 @@ public class SparkUnmarshallerTest {
         return SparkCsvReader.readInput(session,
                 sourceFile,
                 null,
-                columnHeaders);
+                columnHeaders,
+                /* skipHeaderNormalization */ true);
     }
 
     @Test
@@ -98,7 +99,7 @@ public class SparkUnmarshallerTest {
     @Test
     public void unmarshalDataParquetUnencryptedMixedTypesTest() {
         final Dataset<Row> mixedDataset = SparkParquetReader
-                .readInput(session, "../samples/parquet/data_sample_with_non_string_types.parquet");
+                .readInput(session, "../samples/parquet/data_sample_with_non_string_types.parquet", /* skipHeaderNormalization */ true);
         // assert there is indeed a non-String type
         assertTrue(mixedDataset.schema().toList().filter(struct -> struct.dataType() != DataTypes.StringType).size() > 0);
 

--- a/c3r-cli-spark/src/test/java/com/amazonaws/c3r/spark/io/parquet/SparkParquetReaderTest.java
+++ b/c3r-cli-spark/src/test/java/com/amazonaws/c3r/spark/io/parquet/SparkParquetReaderTest.java
@@ -4,6 +4,7 @@
 package com.amazonaws.c3r.spark.io.parquet;
 
 import com.amazonaws.c3r.config.ClientSettings;
+import com.amazonaws.c3r.config.ColumnHeader;
 import com.amazonaws.c3r.config.TableSchema;
 import com.amazonaws.c3r.encryption.keys.KeyUtil;
 import com.amazonaws.c3r.exception.C3rRuntimeException;
@@ -26,6 +27,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static com.amazonaws.c3r.spark.utils.GeneralTestUtility.DATA_SAMPLE_HEADERS;
+import static com.amazonaws.c3r.spark.utils.GeneralTestUtility.DATA_SAMPLE_HEADERS_NO_NORMALIZATION;
 import static com.amazonaws.c3r.spark.utils.GeneralTestUtility.EXAMPLE_SALT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -65,16 +68,22 @@ public class SparkParquetReaderTest {
     public void readInputColumnsTest() {
         final Dataset<Row> dataset = SparkParquetReader.readInput(session, config.getSourceFile());
         final List<String> columns = Arrays.stream(dataset.columns())
-                .map(String::toLowerCase)
                 .sorted()
                 .collect(Collectors.toList());
-        final List<String> expectedColumns = schema.getColumns().stream()
-                .map(columnSchema -> columnSchema.getSourceHeader().toString())
-                .distinct()
+        assertEquals(
+                DATA_SAMPLE_HEADERS.stream().map(ColumnHeader::toString).sorted().collect(Collectors.toList()),
+                columns);
+    }
+
+    @Test
+    public void readInputColumnsNoNormalizationTest() {
+        final Dataset<Row> dataset = SparkParquetReader.readInput(session, config.getSourceFile(), /* skipHeaderNormalization */ true);
+        final List<String> columns = Arrays.stream(dataset.columns())
                 .sorted()
                 .collect(Collectors.toList());
-        assertEquals(expectedColumns.size(), columns.size());
-        assertTrue(expectedColumns.containsAll(columns));
+        assertEquals(
+                DATA_SAMPLE_HEADERS_NO_NORMALIZATION.stream().map(ColumnHeader::toString).sorted().collect(Collectors.toList()),
+                columns);
     }
 
     @Test

--- a/c3r-cli-spark/src/test/java/com/amazonaws/c3r/spark/io/parquet/SparkParquetWriterTest.java
+++ b/c3r-cli-spark/src/test/java/com/amazonaws/c3r/spark/io/parquet/SparkParquetWriterTest.java
@@ -53,13 +53,17 @@ public class SparkParquetWriterTest {
 
     @Test
     public void writeOutputTest() {
-        final Dataset<Row> originalDataset = SparkParquetReader.readInput(session, config.getSourceFile());
+        final Dataset<Row> originalDataset = SparkParquetReader.readInput(
+                session,
+                config.getSourceFile());
         final List<String> originalColumns = Arrays.stream(originalDataset.columns())
                 .map(String::toLowerCase)
                 .sorted()
                 .collect(Collectors.toList());
         SparkParquetWriter.writeOutput(originalDataset, config.getTargetFile());
-        final Dataset<Row> newDataset = SparkParquetReader.readInput(session, config.getTargetFile());
+        final Dataset<Row> newDataset = SparkParquetReader.readInput(
+                session,
+                config.getTargetFile());
         final List<String> newColumns = Arrays.stream(originalDataset.columns())
                 .map(String::toLowerCase)
                 .sorted()

--- a/c3r-cli-spark/src/test/java/com/amazonaws/c3r/spark/utils/GeneralTestUtility.java
+++ b/c3r-cli-spark/src/test/java/com/amazonaws/c3r/spark/utils/GeneralTestUtility.java
@@ -46,16 +46,27 @@ public abstract class GeneralTestUtility {
     /**
      * List of headers from the golden test file (data_sample.csv).
      */
+    public static final List<String> DATA_SAMPLE_HEADER_STRINGS =
+            List.of("FirstName",
+                    "LastName",
+                    "Address",
+                    "City",
+                    "State",
+                    "PhoneNumber",
+                    "Title",
+                    "Level",
+                    "Notes"
+            );
+
+    public static final List<ColumnHeader> DATA_SAMPLE_HEADERS_NO_NORMALIZATION =
+            DATA_SAMPLE_HEADER_STRINGS.stream()
+                    .map(ColumnHeader::ofRaw)
+                    .collect(Collectors.toList());
+
     public static final List<ColumnHeader> DATA_SAMPLE_HEADERS =
-            List.of(new ColumnHeader("FirstName"),
-                    new ColumnHeader("LastName"),
-                    new ColumnHeader("Address"),
-                    new ColumnHeader("City"),
-                    new ColumnHeader("State"),
-                    new ColumnHeader("PhoneNumber"),
-                    new ColumnHeader("Title"),
-                    new ColumnHeader("Level"),
-                    new ColumnHeader("Notes"));
+            DATA_SAMPLE_HEADER_STRINGS.stream()
+                    .map(ColumnHeader::new)
+                    .collect(Collectors.toList());
 
     /**
      * Schema for data_sample.csv.

--- a/c3r-cli/src/main/java/com/amazonaws/c3r/io/schema/SchemaGeneratorUtils.java
+++ b/c3r-cli/src/main/java/com/amazonaws/c3r/io/schema/SchemaGeneratorUtils.java
@@ -26,7 +26,7 @@ public final class SchemaGeneratorUtils {
         if (columnHeader != null) {
             return "column `" + columnHeader + "`";
         } else {
-            return ColumnHeader.getColumnHeaderFromIndex(columnIndex).toString();
+            return ColumnHeader.of(columnIndex).toString();
         }
     }
 

--- a/c3r-cli/src/main/java/com/amazonaws/c3r/io/schema/TemplateSchemaGenerator.java
+++ b/c3r-cli/src/main/java/com/amazonaws/c3r/io/schema/TemplateSchemaGenerator.java
@@ -172,7 +172,7 @@ public final class TemplateSchemaGenerator {
             final var entryArray = new JsonArray(1);
             // template entry
             final var templateEntry = new JsonObject();
-            templateEntry.addProperty("targetHeader", ColumnHeader.getColumnHeaderFromIndex(i).toString());
+            templateEntry.addProperty("targetHeader", ColumnHeader.of(i).toString());
             if (sourceColumnTypes.get(i).supportsCryptographicComputing()) {
                 templateEntry.addProperty("type", columnTypeOptions);
                 templateEntry.add("pad", EXAMPLE_PAD);

--- a/c3r-sdk-core/src/main/java/com/amazonaws/c3r/action/CsvRowUnmarshaller.java
+++ b/c3r-sdk-core/src/main/java/com/amazonaws/c3r/action/CsvRowUnmarshaller.java
@@ -72,8 +72,11 @@ public final class CsvRowUnmarshaller {
             final String csvInputNullValue,
             final String csvOutputNullValue,
             @NonNull final Map<ColumnType, Transformer> transformers) {
-        final RowReader<CsvValue> reader = CsvRowReader.builder().sourceName(sourceFile)
-                .inputNullValue(csvInputNullValue).build();
+        final RowReader<CsvValue> reader = CsvRowReader.builder()
+                .sourceName(sourceFile)
+                .inputNullValue(csvInputNullValue)
+                .skipHeaderNormalization(true)
+                .build();
         final RowWriter<CsvValue> writer = CsvRowWriter.builder()
                 .targetName(targetFile)
                 .outputNullValue(csvOutputNullValue)

--- a/c3r-sdk-core/src/main/java/com/amazonaws/c3r/config/PositionalTableSchema.java
+++ b/c3r-sdk-core/src/main/java/com/amazonaws/c3r/config/PositionalTableSchema.java
@@ -54,7 +54,7 @@ public class PositionalTableSchema extends TableSchema {
      */
     public static List<ColumnHeader> generatePositionalSourceHeaders(final int sourceColumnCount) {
         return IntStream.range(0, sourceColumnCount)
-                .mapToObj(ColumnHeader::getColumnHeaderFromIndex)
+                .mapToObj(ColumnHeader::of)
                 .collect(Collectors.toUnmodifiableList());
     }
 
@@ -122,7 +122,7 @@ public class PositionalTableSchema extends TableSchema {
                     "Missing target header in column " + (sourceColumnIndex + 1) + ".");
         }
         return ColumnSchema.builder()
-                .sourceHeader(ColumnHeader.getColumnHeaderFromIndex(sourceColumnIndex))
+                .sourceHeader(ColumnHeader.of(sourceColumnIndex))
                 .targetHeader(column.getTargetHeader())
                 .pad(column.getPad())
                 .type(column.getType())
@@ -146,7 +146,7 @@ public class PositionalTableSchema extends TableSchema {
             mappedColumns = mapPositionalColumns();
         }
         if (sourceHeaders == null) {
-            sourceHeaders = IntStream.range(0, columns.size()).mapToObj(ColumnHeader::getColumnHeaderFromIndex)
+            sourceHeaders = IntStream.range(0, columns.size()).mapToObj(ColumnHeader::of)
                     .collect(Collectors.toUnmodifiableList());
         }
         super.validate();

--- a/c3r-sdk-core/src/test/java/com/amazonaws/c3r/config/ColumnHeaderTest.java
+++ b/c3r-sdk-core/src/test/java/com/amazonaws/c3r/config/ColumnHeaderTest.java
@@ -27,6 +27,12 @@ public class ColumnHeaderTest {
     }
 
     @Test
+    public void ofRawErrorsOnNullTest() {
+        assertThrows(C3rIllegalArgumentException.class, () -> ColumnHeader.ofRaw(null));
+
+    }
+
+    @Test
     public void checkEmptyStringToConstructorTest() {
         assertThrows(C3rIllegalArgumentException.class, () -> new ColumnHeader(""));
 
@@ -96,7 +102,15 @@ public class ColumnHeaderTest {
     }
 
     @Test
-    public void checkGlueMaxLengthStringConstructorTest() {
+    public void noNormalizationToStringTest() {
+        final String rawString = "ThIs iS a WEIrD StrING ";
+        final ColumnHeader rawHeader = ColumnHeader.ofRaw(rawString);
+
+        assertEquals(rawString, rawHeader.toString());
+    }
+
+    @Test
+    public void maxLengthTest() {
         assertDoesNotThrow(
                 () -> new ColumnHeader("a".repeat(Limits.AWS_CLEAN_ROOMS_HEADER_MAX_LENGTH)));
         assertThrows(
@@ -105,7 +119,7 @@ public class ColumnHeaderTest {
     }
 
     @Test
-    public void checkHeaderNonGlueConformantHeaderNameTest() {
+    public void invalidHeaderNameTest() {
         assertFalse(Limits.AWS_CLEAN_ROOMS_HEADER_REGEXP.matcher("Multi Line\n Header").matches());
         assertThrows(
                 C3rIllegalArgumentException.class,
@@ -115,8 +129,8 @@ public class ColumnHeaderTest {
     // Check that we generate the expected valid and invalid results when creating a header from index.
     @Test
     public void columnHeaderFromIndexTest() {
-        assertEquals(new ColumnHeader("_c0"), ColumnHeader.getColumnHeaderFromIndex(0));
-        assertThrows(C3rIllegalArgumentException.class, () -> ColumnHeader.getColumnHeaderFromIndex(-10));
+        assertEquals(new ColumnHeader("_c0"), ColumnHeader.of(0));
+        assertThrows(C3rIllegalArgumentException.class, () -> ColumnHeader.of(-10));
     }
 
     // Make sure we check all cases of configuring potentially unnamed target headers and verify output.

--- a/c3r-sdk-core/src/test/java/com/amazonaws/c3r/config/PositionalTableSchemaTest.java
+++ b/c3r-sdk-core/src/test/java/com/amazonaws/c3r/config/PositionalTableSchemaTest.java
@@ -116,18 +116,18 @@ public class PositionalTableSchemaTest implements TableSchemaCommonTestInterface
     @Test
     public void verifyAutomaticHeaderConstructionTest() {
         final List<ColumnHeader> knownGoodHeaders = List.of(
-                ColumnHeader.getColumnHeaderFromIndex(0),
-                ColumnHeader.getColumnHeaderFromIndex(1),
-                ColumnHeader.getColumnHeaderFromIndex(2),
-                ColumnHeader.getColumnHeaderFromIndex(3),
-                ColumnHeader.getColumnHeaderFromIndex(4),
-                ColumnHeader.getColumnHeaderFromIndex(5)
+                ColumnHeader.of(0),
+                ColumnHeader.of(1),
+                ColumnHeader.of(2),
+                ColumnHeader.of(3),
+                ColumnHeader.of(4),
+                ColumnHeader.of(5)
         );
         final List<ColumnHeader> knownGoodHeadersInUse = List.of(
-                ColumnHeader.getColumnHeaderFromIndex(1),
-                ColumnHeader.getColumnHeaderFromIndex(2),
-                ColumnHeader.getColumnHeaderFromIndex(4),
-                ColumnHeader.getColumnHeaderFromIndex(5)
+                ColumnHeader.of(1),
+                ColumnHeader.of(2),
+                ColumnHeader.of(4),
+                ColumnHeader.of(5)
         );
         final List<List<ColumnSchema>> positionalColumns = List.of(
                 new ArrayList<>(),
@@ -147,7 +147,7 @@ public class PositionalTableSchemaTest implements TableSchemaCommonTestInterface
     @Override
     @Test
     public void oneSourceToManyTargetsTest() {
-        final ColumnHeader knownGoodHeader = ColumnHeader.getColumnHeaderFromIndex(0);
+        final ColumnHeader knownGoodHeader = ColumnHeader.of(0);
         final PositionalTableSchema schema = new PositionalTableSchema(
                 List.of(
                         List.of(CS_1, CS_2, CS_3, CS_4, CS_5)
@@ -307,7 +307,7 @@ public class PositionalTableSchemaTest implements TableSchemaCommonTestInterface
         final var skippedEmpty = schema.getColumns();
         assertEquals(1, skippedEmpty.size());
         assertNull(emptyColumn.get(1).get(0).getSourceHeader());
-        assertEquals(ColumnHeader.getColumnHeaderFromIndex(1), skippedEmpty.get(0).getSourceHeader());
+        assertEquals(ColumnHeader.of(1), skippedEmpty.get(0).getSourceHeader());
     }
 
     // Make sure the various states of unspecified headers are correct for the child implementation.
@@ -315,9 +315,9 @@ public class PositionalTableSchemaTest implements TableSchemaCommonTestInterface
     @Test
     public void verifyGetUnspecifiedHeadersReturnValueTest() throws IllegalAccessException, NoSuchFieldException {
         final List<ColumnHeader> knownGoodColumns = List.of(
-                ColumnHeader.getColumnHeaderFromIndex(0),
-                ColumnHeader.getColumnHeaderFromIndex(1),
-                ColumnHeader.getColumnHeaderFromIndex(2)
+                ColumnHeader.of(0),
+                ColumnHeader.of(1),
+                ColumnHeader.of(2)
         );
         final var schema = mock(PositionalTableSchema.class);
         doCallRealMethod().when(schema).getPositionalColumnHeaders();
@@ -362,7 +362,7 @@ public class PositionalTableSchemaTest implements TableSchemaCommonTestInterface
     public void positionalSourceHeadersTest() {
         assertTrue(PositionalTableSchema.generatePositionalSourceHeaders(0).isEmpty());
         assertEquals(
-                List.of(ColumnHeader.getColumnHeaderFromIndex(0), ColumnHeader.getColumnHeaderFromIndex(1)),
+                List.of(ColumnHeader.of(0), ColumnHeader.of(1)),
                 PositionalTableSchema.generatePositionalSourceHeaders(2));
     }
 }

--- a/c3r-sdk-core/src/test/java/com/amazonaws/c3r/io/CsvRowReaderTest.java
+++ b/c3r-sdk-core/src/test/java/com/amazonaws/c3r/io/CsvRowReaderTest.java
@@ -26,11 +26,8 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
@@ -38,22 +35,26 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class CsvRowReaderTest {
 
+    private final List<String> dataSampleRawHeaderNames =
+            List.of("FirstName",
+                    "LastName",
+                    "Address",
+                    "City",
+                    "State",
+                    "PhoneNumber",
+                    "Title",
+                    "Level",
+                    "Notes"
+            );
+
     private final List<ColumnHeader> dataSampleHeaders =
-            Stream.of("FirstName",
-                            "LastName",
-                            "Address",
-                            "City",
-                            "State",
-                            "PhoneNumber",
-                            "Title",
-                            "Level",
-                            "Notes"
-                    )
-                    .map(ColumnHeader::new)
-                    .collect(Collectors.toList());
+            dataSampleRawHeaderNames.stream().map(ColumnHeader::new).collect(Collectors.toList());
+
+    private final List<ColumnHeader> dataSampleHeadersNoNormalization =
+            dataSampleRawHeaderNames.stream().map(ColumnHeader::ofRaw).collect(Collectors.toList());
+
     // ColumnSchema Name -> ColumnSchema Value mappings used for convenient testing data
     // LinkedHashMap to ensure ordering of entries for tests that may care
-
     private final Map<String, String> exampleCsvEntries = new LinkedHashMap<>() {
         {
             put("foo", "foo");
@@ -100,13 +101,20 @@ public class CsvRowReaderTest {
     @Test
     public void getHeadersTest() {
         cReader = CsvRowReader.builder().sourceName("../samples/csv/data_sample_without_quotes.csv").build();
+        assertEquals(dataSampleHeaders, cReader.getHeaders());
+    }
 
-        assertFalse(cReader.getHeaders().isEmpty());
-        assertArrayEquals(new ColumnHeader[]{new ColumnHeader("firstname"), new ColumnHeader("lastname"), new ColumnHeader("address"),
-                        new ColumnHeader("city"), new ColumnHeader("state"),
-                        new ColumnHeader("phonenumber"), new ColumnHeader("title"), new ColumnHeader("level"),
-                        new ColumnHeader("notes")},
-                cReader.getHeaders().toArray());
+    @Test
+    public void getHeadersNormalizationTest() {
+        // explicitly normalize the headers and make sure they match the expected values
+        cReader = CsvRowReader.builder().sourceName("../samples/csv/data_sample_without_quotes.csv").skipHeaderNormalization(false).build();
+        assertEquals(dataSampleHeaders, cReader.getHeaders());
+    }
+
+    @Test
+    public void getHeadersNoNormalizationTest() {
+        cReader = CsvRowReader.builder().sourceName("../samples/csv/data_sample_without_quotes.csv").skipHeaderNormalization(true).build();
+        assertEquals(dataSampleHeadersNoNormalization, cReader.getHeaders());
     }
 
     @Test

--- a/c3r-sdk-core/src/test/java/com/amazonaws/c3r/json/PositionalTableSchemaTypeAdapterTest.java
+++ b/c3r-sdk-core/src/test/java/com/amazonaws/c3r/json/PositionalTableSchemaTypeAdapterTest.java
@@ -161,7 +161,7 @@ public final class PositionalTableSchemaTypeAdapterTest implements TableSchemaCo
     // Take in a set of values and construct a column schema with the index as the source header.
     private static ColumnSchema makeColumnSchema(final int idx, final KnownPartsToCompare known) {
         return ColumnSchema.builder()
-                .sourceHeader(ColumnHeader.getColumnHeaderFromIndex(idx))
+                .sourceHeader(ColumnHeader.of(idx))
                 .targetHeader(known.target)
                 .pad(known.pad)
                 .type(known.colType)
@@ -191,18 +191,18 @@ public final class PositionalTableSchemaTypeAdapterTest implements TableSchemaCo
         final ColumnSchema col1Cleartext = cols.get(0);
         final ColumnSchema col1Sealed = cols.get(1);
         final ColumnSchema col1Fingerprint = cols.get(2);
-        assertEquals(ColumnHeader.getColumnHeaderFromIndex(0), col1Cleartext.getSourceHeader());
+        assertEquals(ColumnHeader.of(0), col1Cleartext.getSourceHeader());
         assertEquals("column 1 cleartext", col1Cleartext.getTargetHeader().toString());
         assertEquals(ColumnType.CLEARTEXT, col1Cleartext.getType());
-        assertEquals(ColumnHeader.getColumnHeaderFromIndex(0), col1Sealed.getSourceHeader());
+        assertEquals(ColumnHeader.of(0), col1Sealed.getSourceHeader());
         assertEquals("column 1 sealed", col1Sealed.getTargetHeader().toString());
         assertEquals(ColumnType.SEALED, col1Sealed.getType());
         assertEquals(Pad.DEFAULT, col1Sealed.getPad());
-        assertEquals(ColumnHeader.getColumnHeaderFromIndex(0), col1Fingerprint.getSourceHeader());
+        assertEquals(ColumnHeader.of(0), col1Fingerprint.getSourceHeader());
         assertEquals("column 1 fingerprint", col1Fingerprint.getTargetHeader().toString());
         assertEquals(ColumnType.FINGERPRINT, col1Fingerprint.getType());
         final ColumnSchema col3 = cols.get(3);
-        assertEquals(ColumnHeader.getColumnHeaderFromIndex(2), col3.getSourceHeader());
+        assertEquals(ColumnHeader.of(2), col3.getSourceHeader());
         assertEquals("column 3", col3.getTargetHeader().toString());
         assertEquals(ColumnType.CLEARTEXT, col3.getType());
     }

--- a/c3r-sdk-parquet/src/main/java/com/amazonaws/c3r/action/ParquetRowUnmarshaller.java
+++ b/c3r-sdk-parquet/src/main/java/com/amazonaws/c3r/action/ParquetRowUnmarshaller.java
@@ -64,7 +64,10 @@ public final class ParquetRowUnmarshaller {
             @NonNull final String sourceFile,
             @NonNull final String targetFile,
             @NonNull final Map<ColumnType, Transformer> transformers) {
-        final ParquetRowReader reader = new ParquetRowReader(sourceFile);
+        final ParquetRowReader reader = ParquetRowReader.builder()
+                .sourceName(sourceFile)
+                .skipHeaderNormalization(true)
+                .build();
         final var parquetSchema = reader.getParquetSchema();
         final ParquetRowWriter writer = ParquetRowWriter.builder()
                 .targetName(targetFile)

--- a/c3r-sdk-parquet/src/main/java/com/amazonaws/c3r/data/ParquetSchema.java
+++ b/c3r-sdk-parquet/src/main/java/com/amazonaws/c3r/data/ParquetSchema.java
@@ -7,6 +7,7 @@ import com.amazonaws.c3r.config.ColumnHeader;
 import com.amazonaws.c3r.config.ColumnSchema;
 import com.amazonaws.c3r.config.TableSchema;
 import com.amazonaws.c3r.exception.C3rIllegalArgumentException;
+import lombok.Builder;
 import lombok.Getter;
 import org.apache.parquet.schema.MessageType;
 
@@ -54,8 +55,22 @@ public class ParquetSchema {
      * Generate a C3R schema based off of a Parquet schema.
      *
      * @param messageType Apache's Parquet schema
+     * @deprecated Use the {@link ParquetSchema#builder()} method for this class.
      */
+    @Deprecated
     public ParquetSchema(final org.apache.parquet.schema.MessageType messageType) {
+        this(messageType, false);
+    }
+
+    /**
+     * Generate a C3R schema based off of a Parquet schema.
+     *
+     * @param messageType Apache's Parquet schema
+     * @param skipHeaderNormalization Whether headers should be normalized
+     */
+    @Builder
+    private ParquetSchema(final org.apache.parquet.schema.MessageType messageType,
+                          final boolean skipHeaderNormalization) {
         this.messageType = new MessageType(messageType.getName(), messageType.getFields());
         headers = new ArrayList<>();
         columnIndices = new HashMap<>();
@@ -63,7 +78,9 @@ public class ParquetSchema {
         final var parquetTypes = new HashMap<ColumnHeader, ParquetDataType>();
         final var clientTypes = new ArrayList<ClientDataType>(messageType.getFieldCount());
         for (int i = 0; i < messageType.getFieldCount(); i++) {
-            final ColumnHeader column = new ColumnHeader(messageType.getFieldName(i));
+            final ColumnHeader column = skipHeaderNormalization
+                    ? ColumnHeader.ofRaw(messageType.getFieldName(i))
+                    : new ColumnHeader(messageType.getFieldName(i));
             headers.add(column);
             columnIndices.put(column, i);
             final org.apache.parquet.schema.Type originalType = messageType.getType(i);

--- a/c3r-sdk-parquet/src/test/java/com/amazonaws/c3r/data/ParquetSchemaTest.java
+++ b/c3r-sdk-parquet/src/test/java/com/amazonaws/c3r/data/ParquetSchemaTest.java
@@ -100,4 +100,49 @@ public class ParquetSchemaTest {
                                 .build()
                 ))));
     }
+
+    @Test
+    public void getHeadersTest() {
+        final var messageType = new MessageType("NameAndAge", List.of(
+                Types.optional(PrimitiveType.PrimitiveTypeName.BINARY)
+                        .as(LogicalTypeAnnotation.stringType())
+                        .named("Name"),
+                Types.optional(PrimitiveType.PrimitiveTypeName.INT32)
+                        .named("Age")
+        ));
+        final var schema = ParquetSchema.builder().messageType(messageType).build();
+        assertEquals(
+                List.of(new ColumnHeader("Name"), new ColumnHeader("Age")),
+                schema.getHeaders());
+    }
+
+    @Test
+    public void getHeadersWithNormalizationTest() {
+        final var messageType = new MessageType("NameAndAge", List.of(
+                Types.optional(PrimitiveType.PrimitiveTypeName.BINARY)
+                        .as(LogicalTypeAnnotation.stringType())
+                        .named("Name"),
+                Types.optional(PrimitiveType.PrimitiveTypeName.INT32)
+                        .named("Age")
+        ));
+        final var schema = ParquetSchema.builder().messageType(messageType).skipHeaderNormalization(false).build();
+        assertEquals(
+                List.of(new ColumnHeader("name"), new ColumnHeader("age")),
+                schema.getHeaders());
+    }
+
+    @Test
+    public void getHeadersWithoutNormalizationTest() {
+        final var messageType = new MessageType("NameAndAge", List.of(
+                Types.optional(PrimitiveType.PrimitiveTypeName.BINARY)
+                        .as(LogicalTypeAnnotation.stringType())
+                        .named("Name"),
+                Types.optional(PrimitiveType.PrimitiveTypeName.INT32)
+                        .named("Age")
+        ));
+        final var schema = ParquetSchema.builder().messageType(messageType).skipHeaderNormalization(true).build();
+        assertEquals(
+                List.of(ColumnHeader.ofRaw("Name"), ColumnHeader.ofRaw("Age")),
+                schema.getHeaders());
+    }
 }

--- a/c3r-sdk-parquet/src/test/java/com/amazonaws/c3r/io/ParquetRowReaderTest.java
+++ b/c3r-sdk-parquet/src/test/java/com/amazonaws/c3r/io/ParquetRowReaderTest.java
@@ -104,10 +104,40 @@ public class ParquetRowReaderTest {
 
     @Test
     public void getHeadersTest() {
-        final var pReader = new ParquetRowReader(ParquetTestUtility.PARQUET_1_ROW_PRIM_DATA_PATH);
+        final var pReader = ParquetRowReader.builder()
+                .sourceName(ParquetTestUtility.PARQUET_1_ROW_PRIM_DATA_PATH)
+                .build();
         assertEquals(
                 ParquetTestUtility.PARQUET_TEST_DATA_HEADERS,
                 pReader.getHeaders());
+    }
+
+    @Test
+    public void getHeadersWithNormalizationTest() {
+        final var pReader = ParquetRowReader.builder()
+                .sourceName(ParquetTestUtility.PARQUET_SAMPLE_DATA_PATH)
+                .skipHeaderNormalization(false)
+                .build();
+        assertEquals(
+                ParquetTestUtility.PARQUET_SAMPLE_DATA_HEADERS,
+                pReader.getHeaders());
+        assertEquals(
+                ParquetTestUtility.PARQUET_SAMPLE_DATA_HEADERS,
+                pReader.getParquetSchema().getHeaders());
+    }
+
+    @Test
+    public void getHeadersWithoutNormalizationTest() {
+        final var pReader = ParquetRowReader.builder()
+                .sourceName(ParquetTestUtility.PARQUET_SAMPLE_DATA_PATH)
+                .skipHeaderNormalization(true)
+                .build();
+        assertEquals(
+                ParquetTestUtility.PARQUET_SAMPLE_DATA_HEADERS_NO_NORMALIZATION,
+                pReader.getHeaders());
+        assertEquals(
+                ParquetTestUtility.PARQUET_SAMPLE_DATA_HEADERS_NO_NORMALIZATION,
+                pReader.getParquetSchema().getHeaders());
     }
 
     @Test

--- a/c3r-sdk-parquet/src/test/java/com/amazonaws/c3r/utils/ParquetTestUtility.java
+++ b/c3r-sdk-parquet/src/test/java/com/amazonaws/c3r/utils/ParquetTestUtility.java
@@ -21,6 +21,41 @@ import static java.util.Map.entry;
  * Utility class for testing Parquet functionality.
  */
 public final class ParquetTestUtility {
+
+    public static final String PARQUET_SAMPLE_DATA_PATH = "../samples/parquet/data_sample.parquet";
+
+    /**
+     * Raw column names and types for {@link #PARQUET_SAMPLE_DATA_PATH}.
+     */
+    public static final List<Map.Entry<String, ClientDataType>> PARQUET_SAMPLE_DATA_ROW_TYPE_ENTRIES =
+            List.of(entry("FirstName", ClientDataType.STRING),
+                    entry("LastName", ClientDataType.STRING),
+                    entry("Address", ClientDataType.STRING),
+                    entry("City", ClientDataType.STRING),
+                    entry("State", ClientDataType.STRING),
+                    entry("PhoneNumber", ClientDataType.STRING),
+                    entry("Title", ClientDataType.STRING),
+                    entry("Level", ClientDataType.STRING),
+                    entry("Notes", ClientDataType.STRING));
+
+    /**
+     * ColumnHeaders for {@link #PARQUET_SAMPLE_DATA_PATH}.
+     */
+    public static final List<ColumnHeader> PARQUET_SAMPLE_DATA_HEADERS =
+            PARQUET_SAMPLE_DATA_ROW_TYPE_ENTRIES.stream()
+                    .map(Map.Entry::getKey)
+                    .map(ColumnHeader::new)
+                    .collect(Collectors.toList());
+
+    /**
+     * Non-normalized ColumnHeaders for {@link #PARQUET_SAMPLE_DATA_PATH}.
+     */
+    public static final List<ColumnHeader> PARQUET_SAMPLE_DATA_HEADERS_NO_NORMALIZATION =
+            PARQUET_SAMPLE_DATA_ROW_TYPE_ENTRIES.stream()
+                    .map(Map.Entry::getKey)
+                    .map(ColumnHeader::ofRaw)
+                    .collect(Collectors.toList());
+
     /**
      * A file containing a single row and single column of Parquet data.
      */


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
+ Decryption/unmarshalling modes now do not modify headers
+ `ColumnHeader` has a static factory method that bypasses normalization (`ColumnHeader::ofRaw`)
+ `CsvRowReader` spins up a temporary parser just used to parse the header (to avoid whitespace trimming and other features of the standard CSV parser we still apply to the body of the CSV file) - see `extractHeadersWithoutNormalization`

*Deprecations*
+ `ColumnHeader:: getColumnHeaderFromIndex` - use `ColumnHeader::of(int)` instead
+ `ParquetSchema(MessageType)` - use `ParquetSchema::builder()`
+ `ParquetRowReader(String)` - use `ParquetRowReader::builder()`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.