### PR TITLE
test(spark): Add validations to for malicious column headers in source files

### DIFF
--- a/c3r-cli-spark/src/test/java/com/amazonaws/c3r/spark/io/csv/SparkCsvReaderTest.java
+++ b/c3r-cli-spark/src/test/java/com/amazonaws/c3r/spark/io/csv/SparkCsvReaderTest.java
@@ -4,6 +4,7 @@
 package com.amazonaws.c3r.spark.io.csv;
 
 import com.amazonaws.c3r.config.ColumnHeader;
+import com.amazonaws.c3r.exception.C3rIllegalArgumentException;
 import com.amazonaws.c3r.exception.C3rRuntimeException;
 import com.amazonaws.c3r.io.CsvRowReader;
 import com.amazonaws.c3r.spark.config.SparkConfig;
@@ -235,5 +236,17 @@ public class SparkCsvReaderTest {
         // ensure empty value respected
         assertNotNull(data.get(0).get(1));
         assertEquals("", data.get(0).getString(1));
+    }
+
+    @Test
+    public void maliciousColumnHeaderTest() throws IOException {
+        final String singleRowQuotedSpace = "'; DROP ALL TABLES;";
+        Files.writeString(tempFile, singleRowQuotedSpace);
+
+        // Assert a malicious column header can't be read
+        assertThrows(C3rIllegalArgumentException.class, () -> SparkCsvReader.readInput(session,
+                tempFile.toString(),
+                null,
+                null));
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- There is a grey area around how Spark handles SQL. Normally, SQL is escaped in accordance with the SQL driver being used. Spark does not provide the same SQL injection protections that other languages do since the underlying SQL driver may not be known. 
- For a ColumnHeader to be constructed, it must have a value that matches `[a-z0-9_](([a-z0-9_ ]+-)*([a-z0-9_ ]+))?`
- Our custom CSV reader will fail trying to turn any malicious columns into a ColumnHeader.
- Spark's Parquet reader will permit a malicious value, but the value will be dropped before we ever construct SQL queries when we run `SparkMarshaller.filterSourceColumnsBySchema`.
- If a malicious header were in the dataset somehow and made it past the filtering, our two methods with SQL built using ColumnHeaders, `SparkMarshaller.updateMaxValuesPerColumn` and `SparkMarshaller.mapSourceToTargetColumns`, will fail to validate the malicious column as a ColumnHeader or be drop it silently since it can't possibly exist in the output respectively.
- There is no other SQL that has user defined input.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.