### PR TITLE
ci: add a job gradle-no-failures to aggregate all build job results

### DIFF
--- a/.github/workflows/gradle-build-ci.yml
+++ b/.github/workflows/gradle-build-ci.yml
@@ -61,3 +61,19 @@ jobs:
         uses: gradle/gradle-build-action@v2.4.2
         with:
           arguments: build --parallel
+
+  # Here we wait on all builds and then check if any included "failure"
+  # in the result. This should mean `gradle-no-failures` is successful
+  # if and only if all builds either succed or are skipped (e.g., due to
+  # the `skip-duplicate-actions` action).
+  gradle-no-failures:
+    runs-on: ubuntu-latest
+    needs: gradle
+    if: always()
+    steps:
+      - name: All builds ok
+        if: ${{ !(contains(needs.*.result, 'failure')) }}
+        run: exit 0
+      - name: Some builds failed
+        if: ${{ contains(needs.*.result, 'failure') }}
+        run: exit 1


### PR DESCRIPTION
The gradle-no-failures CI job will pass if no build job failed (i.e., all build jobs succeeded or were skipped due to being a duplicate build that already succeeded).

This should allow us to block PR merging in a way that is compatible with our usage of the `fkirc/skip-duplicate-actions` action, which skips a build if it has succeeded elsewhere in CI. Previously the skipping of previously successful build jobs interfered with making the build jobs required to merge. This new job alleviates that problem by letting it be the blocking action instead of the (possibly skipped) build jobs themselves.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.