### PR TITLE
ci: pin spark integration tests to 3.4.1, not latest release

### DIFF
--- a/c3r-cli-spark/src/integration-test/spark_integration_tests.py
+++ b/c3r-cli-spark/src/integration-test/spark_integration_tests.py
@@ -33,7 +33,8 @@ def latest_spark_version() -> str:
     versions.sort()
     return '.'.join(versions[-1])
 
-spark_version=latest_spark_version()
+# spark_version=latest_spark_version()
+spark_version="3.4.1"
 spark_dir:str = f'spark-{spark_version}-bin-hadoop3-scala2.13'
 """Apache Spark directory."""
 spark_tgz:str = f'{spark_dir}.tgz'


### PR DESCRIPTION
Pin spark client integration tests to 3.4.1 and not the latest release, since the client is not always compatible with the latest release (e.g., between when the new release drops and the client get's any needed changes to adapt).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.