### PR TITLE
ci: set ci build to run nightly

### DIFF
--- a/.github/workflows/gradle-build-ci.yml
+++ b/.github/workflows/gradle-build-ci.yml
@@ -7,6 +7,8 @@
 
 name: Run Gradle Build
 on:
+  schedule:
+    - cron: '0 6 * * *' # Run daily @ 6AM UTC/2AM EST
   pull_request:
   push:
     branches: main
@@ -22,8 +24,6 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         java-version: ['11', '17']
     runs-on: ${{ matrix.os }}
-    needs: filter
-    if: ${{ needs.filter.outputs.should_skip != 'true' }}
     steps:
       - name: Set up repository
         uses: actions/checkout@v4


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Set our standard CI build to a nightly schedule as a layer of defense to ensure any pushes to `main`---even those from dependabot---are built and have their result registered with the associated github action.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.