### PR TITLE
ci: disable duplicate build skipping

### DIFF
--- a/.github/workflows/gradle-build-ci.yml
+++ b/.github/workflows/gradle-build-ci.yml
@@ -16,20 +16,6 @@ permissions:
   contents: read
 
 jobs:
-  # Adds the following filters:
-  # Only run when files that influence the build are updated.
-  # Don't run again if the same commit has already been run.
-  filter:
-    runs-on: ubuntu-latest
-    outputs:
-      should_skip: ${{ steps.skip_check.outputs.should_skip }}
-    steps:
-      - id: skip_check
-        uses: fkirc/skip-duplicate-actions@v5.3.0
-        with:
-          concurrent_skipping: 'same_content_newer'
-          paths: '["**/src/**", "**.gradle", "samples/**", "config/**", ".github/workflows/gradle-build-ci.yml"]'
-
   gradle:
     strategy:
       matrix:


### PR DESCRIPTION
Build skipping has caused some problems when combined with dependabot and merge protections. Activity in the C3R repo is at a level where allowing occasional duplicate builds is not anticipated to cause issues and is the simplest solution to the interfering actions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.