### PR TITLE
build(gradle): Bump spark_version from 3.4.1 to 3.5.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ subprojects {
     ext.junit_version = '5.10.1'
     ext.log4j_version = '2.22.0'
     ext.mockito_version = '5.2.0'
-    ext.spark_version = '3.4.1'
+    ext.spark_version = '3.5.0'
 
     dependencies {
         // Logging

--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ subprojects {
     ext.log4j_version = '2.22.0'
     ext.mockito_version = '5.2.0'
     ext.spark_version = '3.5.0'
+    ext.spotbugs_version = '5.1.4'
 
     dependencies {
         // Logging

--- a/c3r-cli-spark/build.gradle
+++ b/c3r-cli-spark/build.gradle
@@ -7,7 +7,7 @@ plugins {
 
     // SpotBugs for quality checks and reports of source files. Read more at:
     // https://spotbugs.readthedocs.io/en/stable/gradle.html
-    id "com.github.spotbugs" version "5.1.4"
+    id "com.github.spotbugs" version "$spotbugs_version"
 
     // Vanilla code generation. Read more at:
     // https://projectlombok.org/

--- a/c3r-cli-spark/src/main/java/com/amazonaws/c3r/spark/action/SparkMarshaller.java
+++ b/c3r-cli-spark/src/main/java/com/amazonaws/c3r/spark/action/SparkMarshaller.java
@@ -22,7 +22,6 @@ import org.apache.spark.sql.Column;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder;
-import org.apache.spark.sql.catalyst.encoders.RowEncoder;
 import org.apache.spark.sql.functions;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructField;
@@ -248,7 +247,7 @@ public abstract class SparkMarshaller {
         final String salt = encryptConfig.getSalt();
         final String base64EncodedKey = Base64.getEncoder().encodeToString(encryptConfig.getSecretKey().getEncoded());
 
-        final ExpressionEncoder<Row> rowEncoder = RowEncoder.apply(rawInputData.schema());
+        final ExpressionEncoder<Row> rowEncoder = ExpressionEncoder.apply(rawInputData.schema());
         final StructField[] fields = rawInputData.schema().fields();
         try {
             return rawInputData.map((MapFunction<Row, Row>) row -> {

--- a/c3r-cli-spark/src/main/java/com/amazonaws/c3r/spark/action/SparkUnmarshaller.java
+++ b/c3r-cli-spark/src/main/java/com/amazonaws/c3r/spark/action/SparkUnmarshaller.java
@@ -13,7 +13,6 @@ import org.apache.spark.api.java.function.MapFunction;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder;
-import org.apache.spark.sql.catalyst.encoders.RowEncoder;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructField;
 import scala.jdk.CollectionConverters;
@@ -92,7 +91,7 @@ public abstract class SparkUnmarshaller {
         final String base64EncodedKey = Base64.getEncoder().encodeToString(decryptConfig.getSecretKey().getEncoded());
         final boolean failOnFingerprintColumns = decryptConfig.isFailOnFingerprintColumns();
 
-        final ExpressionEncoder<Row> rowEncoder = RowEncoder.apply(rawInputData.schema());
+        final ExpressionEncoder<Row> rowEncoder = ExpressionEncoder.apply(rawInputData.schema());
         final StructField[] fields = rawInputData.schema().fields();
         try {
             return rawInputData.map((MapFunction<Row, Row>) row -> {

--- a/c3r-cli/build.gradle
+++ b/c3r-cli/build.gradle
@@ -7,7 +7,7 @@ plugins {
 
     // SpotBugs for quality checks and reports of source files. Read more at:
     // https://spotbugs.readthedocs.io/en/stable/gradle.html
-    id "com.github.spotbugs" version "5.1.4"
+    id "com.github.spotbugs" version "$spotbugs_version"
 
     // Vanilla code generation. Read more at:
     // https://projectlombok.org/

--- a/c3r-sdk-core/build.gradle
+++ b/c3r-sdk-core/build.gradle
@@ -11,7 +11,7 @@ plugins {
 
     // SpotBugs for quality checks and reports of source files. Read more at:
     // https://spotbugs.readthedocs.io/en/stable/gradle.html
-    id "com.github.spotbugs" version "5.1.4"
+    id "com.github.spotbugs" version "$spotbugs_version"
 
     // Vanilla code generation. Read more at:
     // https://projectlombok.org/

--- a/c3r-sdk-examples/build.gradle
+++ b/c3r-sdk-examples/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
     // SpotBugs for quality checks and reports of source files. Read more at:
     // https://spotbugs.readthedocs.io/en/stable/gradle.html
-    id "com.github.spotbugs" version "5.1.4"
+    id "com.github.spotbugs" version "$spotbugs_version"
 }
 
 apply plugin: 'com.github.spotbugs'

--- a/c3r-sdk-examples/src/main/java/com/amazonaws/c3r/examples/spark/SparkExample.java
+++ b/c3r-sdk-examples/src/main/java/com/amazonaws/c3r/examples/spark/SparkExample.java
@@ -23,7 +23,6 @@ import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SaveMode;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder;
-import org.apache.spark.sql.catalyst.encoders.RowEncoder;
 import org.apache.spark.sql.functions;
 import scala.jdk.CollectionConverters;
 
@@ -323,7 +322,7 @@ public final class SparkExample {
      * @return The encrypted data
      */
     static Dataset<Row> marshalData(final Dataset<Row> rawInputData) {
-        final ExpressionEncoder<Row> rowEncoder = RowEncoder.apply(rawInputData.schema());
+        final ExpressionEncoder<Row> rowEncoder = ExpressionEncoder.apply(rawInputData.schema());
         return rawInputData.map((MapFunction<Row, Row>) row -> {
             // Grab a nonce for the row
             final Nonce nonce = Nonce.nextNonce();
@@ -356,7 +355,7 @@ public final class SparkExample {
      * @return The cleartext data
      */
     static Dataset<Row> unmarshalData(final Dataset<Row> rawInputData) {
-        final ExpressionEncoder<Row> rowEncoder = RowEncoder.apply(rawInputData.schema());
+        final ExpressionEncoder<Row> rowEncoder = ExpressionEncoder.apply(rawInputData.schema());
         return rawInputData.map((MapFunction<Row, Row>) row -> {
             // Build a list of transformers for each row, limiting state to keys/salts/settings POJOs
             final Map<ColumnType, Transformer> transformers = Transformer.initTransformers(

--- a/c3r-sdk-parquet/build.gradle
+++ b/c3r-sdk-parquet/build.gradle
@@ -11,7 +11,7 @@ plugins {
 
     // SpotBugs for quality checks and reports of source files. Read more at:
     // https://spotbugs.readthedocs.io/en/stable/gradle.html
-    id "com.github.spotbugs" version "5.1.4"
+    id "com.github.spotbugs" version "$spotbugs_version"
 
     // Vanilla code generation. Read more at:
     // https://projectlombok.org/


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Fixes the use of RowEncoder.apply to be ExpressionEncoder.apply in order to update from Spark 3.4.1 to 3.5.0
- Moves spotbugs to a variable in the main gradle build file for clean up

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.