### PR TITLE
ci: Locks spotbugs until the merge conflicts with it may be dealt with

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,13 +5,16 @@
 
 version: 2
 updates:
-  - package-ecosystem: "gradle" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "gradle"
+    directory: "/"
     schedule:
       interval: "daily"
       time: "08:00"
     commit-message:
       prefix: "build(gradle)"
+    ignore:
+      # Temporary until conflicts with new Spotbugs version may be updated
+      - dependency-name: "com.github.spotbugs"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Locks spotbugs until the update can be dealt with.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.