### PR TITLE
feat: Encoders/Decoders with Metadata

### DIFF
--- a/c3r-sdk-core/src/main/java/com/amazonaws/c3r/data/ClientValueWithMetadata.java
+++ b/c3r-sdk-core/src/main/java/com/amazonaws/c3r/data/ClientValueWithMetadata.java
@@ -1,0 +1,167 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.amazonaws.c3r.data;
+
+import com.amazonaws.c3r.exception.C3rIllegalArgumentException;
+import lombok.NonNull;
+import lombok.Value;
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.Objects;
+
+/**
+ * Support classes for types that need additional metadata to be encoded and decoded.
+ */
+public final class ClientValueWithMetadata {
+    /**
+     * Utility class private constructor.
+     */
+    private ClientValueWithMetadata() {
+    }
+
+    /**
+     * Checks if all metadata fields are non-null.
+     *
+     * @param metadataFields Array of metadata fields for the type
+     * @return {@code true} if all metadata is non-null
+     */
+    private static boolean allMetaDataIsNonNull(@NonNull final Object[] metadataFields) {
+        return Arrays.stream(metadataFields).allMatch(Objects::nonNull);
+    }
+
+    /**
+     * Check if all metadata fields are null.
+     *
+     * @param metadataFields Array of metadata fields for the type
+     * @return {@code true} if all metadata is null
+     */
+    private static boolean allMetaDataIsNull(@NonNull final Object[] metadataFields) {
+        return Arrays.stream(metadataFields).allMatch(Objects::isNull);
+    }
+
+    /**
+     * Checks that null status of the value and the metadata match. If a value is specified, all metadata must be non-null.
+     * If the value is not specified, all the metadata must be null or all the metadata must be non-null.
+     *
+     * @param value          Value being recreated
+     * @param metadataFields Array of metadata fields for the type
+     * @param type           Name of the client data type for use in error messages
+     * @throws C3rIllegalArgumentException if the null status of the value and metadata does not match
+     */
+    private static void validate(final Object value, final Object[] metadataFields, final String type) {
+        if (value != null && !allMetaDataIsNonNull(metadataFields)) {
+            throw new C3rIllegalArgumentException(type + " values require all metadata must be specified too.");
+        } else if (value == null && !allMetaDataIsNonNull(metadataFields) && !allMetaDataIsNull(metadataFields)) {
+            throw new C3rIllegalArgumentException("Metadata fields for " + type +
+                    " must all be null or all be specified for null values.");
+        }
+    }
+
+    /**
+     * Data and metadata needed to construct a valid decimal value.
+     */
+    @Value
+    public static class Decimal {
+        /**
+         * Fixed point number.
+         */
+        private BigDecimal value;
+
+        /**
+         * Number of digits in the entire value.
+         */
+        private Integer precision;
+
+        /**
+         * Number of digits to the right of the decimal in the value.
+         */
+        private Integer scale;
+
+        /**
+         * All information needed to recreate an instance of a decimal.
+         *
+         * @param value     Fixed precision number
+         * @param precision How many digits are in the number
+         * @param scale     How many digits are to the right of the decimal
+         * @throws C3rIllegalArgumentException if value doesn't conform to precision and scale limits
+         */
+        public Decimal(final BigDecimal value, final Integer precision, final Integer scale) {
+            final Object[] metadata = new Object[]{precision, scale};
+            validate(value, metadata, "Decimal");
+            this.value = value;
+            this.precision = precision;
+            this.scale = scale;
+        }
+    }
+
+    /**
+     * Data and metadata needed to construct a valid timestamp value.
+     */
+    @Value
+    public static class Timestamp {
+        /**
+         * Amount of time.
+         */
+        private Long value;
+
+        /**
+         * If this value is adjusted to UTC.
+         */
+        private Boolean isUtc;
+
+        /**
+         * What unit this value is in.
+         */
+        private Units.Seconds unit;
+
+        /**
+         * All information needed to recreate an instance of a timestamp.
+         *
+         * @param value How much time
+         * @param isUtc If the value is in UTC
+         * @param unit  Unit of seconds
+         * @throws C3rIllegalArgumentException if time value is specified but UTC or unit information is missing
+         */
+        public Timestamp(final Long value, final Boolean isUtc, final Units.Seconds unit) {
+            final Object[] metadata = new Object[]{isUtc, unit};
+            validate(value, metadata, "Timestamp");
+            this.value = value;
+            this.isUtc = isUtc;
+            this.unit = unit;
+        }
+    }
+
+    /**
+     * Data and metadata needed to construct a valid variable length character array value.
+     */
+    @Value
+    public static class Varchar {
+        /**
+         * Variable length character array.
+         */
+        private java.lang.String value;
+
+        /**
+         * Maximum length the variable character array may be.
+         */
+        private Integer maxLength;
+
+        /**
+         * All information needed to recreate an instance of a variable length character array.
+         *
+         * @param value     The variable length character value
+         * @param maxLength The longest length the value can be
+         * @throws C3rIllegalArgumentException if the value and maxLength are an invalid pair
+         */
+        public Varchar(final java.lang.String value, final Integer maxLength) {
+            validate(value, new Object[]{maxLength}, "Varchar");
+            if (value != null && value.length() > maxLength) {
+                throw new C3rIllegalArgumentException("Value cannot be more than maxLength characters long.");
+            }
+            this.value = value;
+            this.maxLength = maxLength;
+        }
+    }
+}

--- a/c3r-sdk-core/src/main/java/com/amazonaws/c3r/data/Units.java
+++ b/c3r-sdk-core/src/main/java/com/amazonaws/c3r/data/Units.java
@@ -1,0 +1,85 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.amazonaws.c3r.data;
+
+import lombok.NonNull;
+
+import java.math.BigInteger;
+
+/**
+ * Units used in C3R data types.
+ */
+public class Units {
+    /**
+     * Supported second based time units and a helper function to convert between units.
+     */
+    public enum Seconds {
+        /**
+         * Milliseconds.
+         */
+        MILLIS,
+
+        /**
+         * Microseconds.
+         */
+        MICROS,
+
+        /**
+         * Nanoseconds.
+         */
+        NANOS;
+
+        /**
+         * Number of microseconds in a millisecond.
+         */
+        private static final BigInteger MILLIS_PER_MICROS = BigInteger.valueOf(1000);
+
+        /**
+         * Number of milliseconds in a nanosecond.
+         */
+        private static final BigInteger MILLIS_PER_NANOS = BigInteger.valueOf(1000000);
+
+        /**
+         * Number of nanoseconds in a microsecond.
+         */
+        private static final BigInteger MICROS_PER_NANOS = BigInteger.valueOf(1000);
+
+        /**
+         * Takes a value in milliseconds, microseconds or nanoseconds and
+         * converts it to the same amount of time in milliseconds, microseconds or nanoseconds.
+         *
+         * @param value Amount of time
+         * @param from  Unit time is currently in
+         * @param to    Unit time should be changed to
+         * @return Same amount of time in new unit value
+         */
+        public static BigInteger convert(final BigInteger value, @NonNull final Seconds from, @NonNull final Seconds to) {
+            if (value == null) {
+                return null;
+            }
+            if (from == to) {
+                return value;
+            }
+            if (from == MILLIS) {
+                if (to == MICROS) {
+                    return value.multiply(MILLIS_PER_MICROS);
+                } else {
+                    return value.multiply(MILLIS_PER_NANOS);
+                }
+            } else if (from == MICROS) {
+                if (to == MILLIS) {
+                    return value.divide(MILLIS_PER_MICROS);
+                } else {
+                    return value.multiply(MICROS_PER_NANOS);
+                }
+            } else {
+                if (to == MILLIS) {
+                    return value.divide(MILLIS_PER_NANOS);
+                } else {
+                    return value.divide(MICROS_PER_NANOS);
+                }
+            }
+        }
+    }
+}

--- a/c3r-sdk-core/src/main/java/com/amazonaws/c3r/data/ValueConverter.java
+++ b/c3r-sdk-core/src/main/java/com/amazonaws/c3r/data/ValueConverter.java
@@ -4,24 +4,159 @@
 package com.amazonaws.c3r.data;
 
 import com.amazonaws.c3r.config.ColumnType;
+import com.amazonaws.c3r.exception.C3rIllegalArgumentException;
 import com.amazonaws.c3r.exception.C3rRuntimeException;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import edu.umd.cs.findbugs.annotations.UnknownNullness;
 import lombok.NonNull;
 
+import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.function.BiFunction;
+import java.util.function.Function;
 
 /**
  * Utility functions to convert values from one type to another based off of column specifications.
+ *
+ * <p>
+ * For encoded values, the byte representation follows the general form:<br/>
+ * Byte 1: {@link ClientDataInfo}<br/>
+ * Bytes 2-(N-1): Metadata if the type needs it to recreate the value<br/>
+ * Bytes N+: Data if the value is not null<br/>
+ * </p>
  */
 public final class ValueConverter {
     /**
      * Private utility class constructor.
      */
     private ValueConverter() {
+    }
+
+    /**
+     * Creates a basic value (i.e., one that requires no metadata) from the given {@code bytes}.
+     *
+     * @param bytes              Bytes representing a simple Java type
+     * @param expectedByteLength How many bytes the value should have
+     * @param type               Name of type to use in error messages
+     * @param getter             Function to call on {@code ByteBuffer} to get the value of type {@code T} that
+     *                           is expected to consume all of the `bytes`.
+     * @param <T>                Java class for the basic value
+     * @return The reconstructed value
+     * @throws C3rRuntimeException if the number of bytes is not the expected length
+     */
+    private static <T> T basicFromBytes(final byte[] bytes, final int expectedByteLength, @NonNull final ClientDataType type,
+                                        @NonNull final Function<ByteBuffer, T> getter) {
+        if (bytes == null) {
+            return null;
+        }
+        if (bytes.length != expectedByteLength) {
+            throw new C3rRuntimeException(type + " should be " + expectedByteLength + " in length but " + bytes.length +
+                    " found.");
+        }
+        final ByteBuffer buffer = ByteBuffer.wrap(bytes);
+        final T value = getter.apply(buffer);
+        if (buffer.hasRemaining()) {
+            throw new C3rRuntimeException(buffer.remaining() + " bytes still left but expected amount has been processed by array.");
+        }
+        return value;
+    }
+
+    /**
+     * Creates an integral number from a byte array using {@code BigInteger} which checks for under and over flows.
+     *
+     * @param bytes  Bytes representing an integral value
+     * @param type   Client data type name to use in error messages
+     * @param getter Function to call on {@code BigInteger} to get value of type {@code T}
+     * @param <T>    The type of integer to retrieve
+     * @return Reconstructed integral number
+     * @throws C3rRuntimeException if the value is out of range for the type
+     */
+    private static <T> T integralFromBytes(final byte[] bytes, @NonNull final ClientDataType type,
+                                           @NonNull final Function<BigInteger, T> getter) {
+        if (bytes == null) {
+            return null;
+        }
+        try {
+            final BigInteger value = new BigInteger(bytes);
+            return getter.apply(value);
+        } catch (final ArithmeticException e) {
+            throw new C3rRuntimeException("Value out of range of a " + type + ".", e);
+        }
+    }
+
+    /**
+     * Creates a string from an array of UTF-8 encoded bytes.
+     *
+     * @param bytes UTF-8 byte array
+     * @return String representation of byte value
+     */
+    private static java.lang.String stringFromBytes(final byte[] bytes) {
+        if (bytes == null) {
+            return null;
+        }
+        return new java.lang.String(bytes, StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Converts a value of a basic type (i.e., one that has no extra metadata) into bytes.
+     *
+     * @param value  What to store
+     * @param size   Length of the value being stored
+     * @param putter Function to call on {@code ByteBuffer} to put the value in
+     * @param <T>    The particular class being stored
+     * @return Byte representation of value
+     * @throws C3rRuntimeException If the value does not fill up the expected number of bytes
+     */
+    private static <T> byte[] basicToBytes(final T value, final int size, @NonNull final BiFunction<ByteBuffer, T, ByteBuffer> putter) {
+        if (value == null) {
+            return null;
+        }
+        final ByteBuffer buffer = ByteBuffer.allocate(size);
+        putter.apply(buffer, value);
+        if (buffer.hasRemaining()) {
+            throw new C3rRuntimeException("Too many bytes in array.");
+        }
+        return buffer.array();
+    }
+
+    /**
+     * Turns a string into its UTF-8 byte representation.
+     *
+     * @param value String to convert to UTF-8 encoded bytes
+     * @return Byte encoding of string value
+     */
+    private static byte[] stringToBytes(final java.lang.String value) {
+        if (value == null) {
+            return null;
+        }
+        return value.getBytes(StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Determines how many bytes will be added to the output. If the value is specified, the metadata parameters must all be specified.
+     * If the value is null the metadata parameters can either all be specified as null or non-null values but not a mix.
+     *
+     * @param value              Value being encoded
+     * @param metadataValues     Array of metadata parameters
+     * @param nonNullValueLength How many bytes will be needed to store metadata for a non-null value
+     * @param nullValueLength    How many bytes will be needed to store metadata when the value is null but the metadata is all non-null
+     * @param <T>                Type of the value being stored
+     * @return Number of bytes that will be needed to store metadata.
+     */
+    private static <T> int getMetaDataByteLength(final T value, @NonNull final Object[] metadataValues, final int nonNullValueLength,
+                                                 final int nullValueLength) {
+        if (value == null && Arrays.stream(metadataValues).allMatch(Objects::nonNull)) {
+            return nullValueLength;
+        } else if (value == null) {
+            return 0;
+        }
+        return nonNullValueLength;
     }
 
     /**
@@ -41,6 +176,124 @@ public final class ValueConverter {
             throw new C3rRuntimeException("Expected to decode " + expected + " but found " + info.getType() + " instead.");
         }
         return info;
+    }
+
+    /**
+     * Verifies that if {@code value} is non-null that all metadata parameters are also non-null
+     * or if {@code value} is null that all metadata parameters have the same nullness.
+     *
+     * @param value    Value to be encoded
+     * @param metadata Parameters needed to correctly reconstitute the value
+     * @return {@code true} if parameters are correctly specified give whether value is null or not
+     */
+    private static boolean metadataSpecifiedIncorrectly(final Object value, final Object[] metadata) {
+        final boolean allNull = Arrays.stream(metadata).allMatch(Objects::isNull);
+        final boolean allNonNull = Arrays.stream(metadata).allMatch(Objects::nonNull);
+        return (value == null || !allNonNull) && (value != null || (!allNull && !allNonNull));
+    }
+
+    /**
+     * Takes a value of type {@code T} and converts it to a byte array.
+     *
+     * @param value  Value of type {@code T} to be converted
+     * @param buffer ByteBuffer used to convert the value to bytes
+     * @param putter Function to call on {@code ByteBuffer} to insert the value
+     * @param <T>    Type of data being stored
+     * @return Byte representation of value
+     */
+    private static <T> byte[] encodeValue(final T value, @NonNull final ByteBuffer buffer, @NonNull final Function<T, ByteBuffer> putter) {
+        if (value != null) {
+            putter.apply(value);
+        }
+        return buffer.array();
+    }
+
+    /**
+     * For types that only need to call a single function on {@code ByteBuffer} to encode the value.
+     *
+     * @param value  Value being encoded
+     * @param type   Client data type being encoded
+     * @param size   Expected size of the value in bytes
+     * @param putter Function to call on {@ByteBuffer} to store the value
+     * @param <T>    Java type being converted to bytes
+     * @return Byte representation of value
+     */
+    private static <T> byte[] basicEncode(final T value, @NonNull final ClientDataType type, @NonNull final Integer size,
+                                          @NonNull final BiFunction<ByteBuffer, T, ByteBuffer> putter) {
+        final ClientDataInfo info = ClientDataInfo.builder().type(type).isNull(value == null).build();
+        final int length = (value == null) ? 0 : size;
+        final ByteBuffer buffer = ByteBuffer.allocate(ClientDataInfo.BYTE_LENGTH + length)
+                .put(info.encode());
+        return encodeValue(value, buffer, x -> putter.apply(buffer, x));
+    }
+
+    /**
+     * Decodes a value that only needs a single call to {@code ByteBuffer} to recreate the value.
+     *
+     * @param bytes  Byte representation of value
+     * @param type   Name of client data type to use in error messages
+     * @param getter Function to call on {@code ByteBuffer} to get the value
+     * @param <T>    The Java type being created
+     * @return Value created from bytes
+     * @throws C3rRuntimeException if the number of bytes is wrong for the type
+     */
+    private static <T> T basicDecode(final byte[] bytes, @NonNull final ClientDataType type,
+                                     @NonNull final Function<ByteBuffer, T> getter) {
+        final ByteBuffer buffer = ByteBuffer.wrap(bytes);
+        final ClientDataInfo info = stripClientDataInfo(buffer, type);
+        if (info.isNull()) {
+            return null;
+        }
+        try {
+            final T value = getter.apply(buffer);
+            checkBuffer(buffer);
+            return value;
+        } catch (BufferUnderflowException e) {
+            throw new C3rRuntimeException("Value could not be decoded, not enough bytes.", e);
+        }
+    }
+
+    /**
+     * Takes a boolean value to a byte array.
+     *
+     * @param value Boolean to turn into bytes
+     * @return Byte array of 1 byte that stores a representation of the boolean value
+     */
+    private static byte[] getBytesFromBoolean(final boolean value) {
+        if (value) {
+            return new byte[]{(byte) 1};
+        } else {
+            return new byte[]{(byte) 0};
+        }
+    }
+
+    /**
+     * Converts a byte value to a boolean value.
+     *
+     * @param value Boolean value as a byte
+     * @return The boolean value the byte represents
+     * @throws C3rIllegalArgumentException if the byte does not represent a valid boolean value
+     */
+    private static boolean getBooleanFromByte(final byte value) {
+        if (value == (byte) 0) {
+            return false;
+        } else if (value == (byte) 1) {
+            return true;
+        } else {
+            throw new C3rIllegalArgumentException("Could not decode boolean value from byte.");
+        }
+    }
+
+    /**
+     * Checks to confirm all bytes have been read from the {@code ByteBuffer}.
+     *
+     * @param buffer {@code ByteBuffer} that should have no remaining bytes to read
+     * @throws C3rRuntimeException If there are still bytes left in the array
+     */
+    private static void checkBuffer(@NonNull final ByteBuffer buffer) {
+        if (buffer.hasRemaining()) {
+            throw new C3rRuntimeException(buffer.remaining() + " bytes still left but expected number of bytes have been decoded.");
+        }
     }
 
     /**
@@ -97,16 +350,7 @@ public final class ValueConverter {
          * @throws C3rRuntimeException If the byte array is more than the max length
          */
         public static Long fromBytes(final byte[] bytes) {
-            if (bytes == null) {
-                return null;
-            } else if (bytes.length > ClientDataType.BIGINT_BYTE_SIZE) {
-                throw new C3rRuntimeException("BigInt values must be " + ClientDataType.BIGINT_BYTE_SIZE + " bytes or less.");
-            }
-            try {
-                return new BigInteger(bytes).longValueExact();
-            } catch (ArithmeticException e) {
-                throw new C3rRuntimeException("Value out of range of a BigInt.");
-            }
+            return integralFromBytes(bytes, ClientDataType.BIGINT, BigInteger::longValueExact);
         }
 
         /**
@@ -129,10 +373,7 @@ public final class ValueConverter {
          * @return Big-endian byte encoding of value
          */
         public static byte[] toBytes(final Long value) {
-            if (value == null) {
-                return null;
-            }
-            return ByteBuffer.allocate(ClientDataType.BIGINT_BYTE_SIZE).putLong(value).array();
+            return basicToBytes(value, ClientDataType.BIGINT_BYTE_SIZE, ByteBuffer::putLong);
         }
 
         /**
@@ -142,14 +383,7 @@ public final class ValueConverter {
          * @return Byte representation of the value and its metadata
          */
         public static byte[] encode(final Long value) {
-            final ClientDataInfo info = ClientDataInfo.builder().type(ClientDataType.BIGINT).isNull(value == null).build();
-            final int length = (value == null) ? 0 : ClientDataType.BIGINT_BYTE_SIZE;
-            final ByteBuffer buffer = ByteBuffer.allocate(ClientDataInfo.BYTE_LENGTH + length)
-                    .put(info.encode());
-            if (value != null) {
-                buffer.putLong(value);
-            }
-            return buffer.array();
+            return basicEncode(value, ClientDataType.BIGINT, ClientDataType.BIGINT_BYTE_SIZE, ByteBuffer::putLong);
         }
 
         /**
@@ -160,16 +394,7 @@ public final class ValueConverter {
          * @throws C3rRuntimeException if not enough bytes are in the encoded value or the data type is not BigInt
          */
         public static Long decode(final byte[] bytes) {
-            final ByteBuffer buffer = ByteBuffer.wrap(bytes);
-            final ClientDataInfo info = stripClientDataInfo(buffer, ClientDataType.BIGINT);
-            if (info.isNull()) {
-                return null;
-            }
-            try {
-                return buffer.getLong();
-            } catch (BufferUnderflowException e) {
-                throw new C3rRuntimeException("Value could not be decoded, not enough bytes.", e);
-            }
+            return basicDecode(bytes, ClientDataType.BIGINT, ByteBuffer::getLong);
         }
     }
 
@@ -182,17 +407,16 @@ public final class ValueConverter {
          *
          * @param bytes byte encoded value
          * @return {@code true} if value is non-zero or {@code false}
+         * @throws C3rRuntimeException if the byte length is not the expected amount
          */
         @UnknownNullness
         public static java.lang.Boolean fromBytes(final byte[] bytes) {
             if (bytes == null) {
                 return null;
+            } else if (bytes.length != 1) {
+                throw new C3rRuntimeException("Boolean value expected to be a single byte.");
             }
-            boolean nonZero = false;
-            for (var b : bytes) {
-                nonZero |= (b != 0);
-            }
-            return nonZero;
+            return getBooleanFromByte(bytes[0]);
         }
 
         /**
@@ -204,11 +428,8 @@ public final class ValueConverter {
         public static byte[] toBytes(final java.lang.Boolean value) {
             if (value == null) {
                 return null;
-            } else if (value) {
-                return new byte[]{(byte) 1};
-            } else {
-                return new byte[]{(byte) 0};
             }
+            return getBytesFromBoolean(value);
         }
 
         /**
@@ -218,14 +439,7 @@ public final class ValueConverter {
          * @return Byte representation of the value and its metadata
          */
         public static byte[] encode(final java.lang.Boolean value) {
-            final ClientDataInfo info = ClientDataInfo.builder().type(ClientDataType.BOOLEAN).isNull(value == null).build();
-            final int length = (value == null) ? 0 : 1;
-            final ByteBuffer buffer =  ByteBuffer.allocate(ClientDataInfo.BYTE_LENGTH + length)
-                    .put(info.encode());
-            if (value != null) {
-                buffer.put(toBytes(value));
-            }
-            return buffer.array();
+            return basicEncode(toBytes(value), ClientDataType.BOOLEAN, Byte.BYTES, ByteBuffer::put);
         }
 
         /**
@@ -237,14 +451,16 @@ public final class ValueConverter {
          */
         @UnknownNullness
         public static java.lang.Boolean decode(final byte[] bytes) {
-
             final ByteBuffer buffer = ByteBuffer.wrap(bytes);
             final ClientDataInfo info = stripClientDataInfo(buffer, ClientDataType.BOOLEAN);
             if (info.isNull()) {
                 return null;
             }
             try {
-                return fromBytes(new byte[]{buffer.get()});
+                final byte[] remaining = new byte[buffer.remaining()];
+                buffer.get(remaining);
+                checkBuffer(buffer);
+                return fromBytes(remaining);
             } catch (BufferUnderflowException e) {
                 throw new C3rRuntimeException("Value could not be decoded, not enough bytes.", e);
             }
@@ -252,7 +468,85 @@ public final class ValueConverter {
     }
 
     /**
-     * Utility functions for converting a C3R Date to and from various representations.
+     * Utility functions for converting a C3R Char to and from various representations.
+     */
+    public static final class Char {
+        /**
+         * Number of bytes of metadata needed to reconstruct a fixed length character array correctly.
+         */
+        private static final int TOTAL_METADATA_BYTES = Integer.BYTES;
+
+        /**
+         * Converts bytes to a fixed length character array.
+         *
+         * @param bytes UTF-8 encoded bytes to convert
+         * @return Fixed length character array
+         */
+        public static char[] fromBytes(final byte[] bytes) {
+            final java.lang.String value = stringFromBytes(bytes);
+            return value == null ? null : value.toCharArray();
+        }
+
+        /**
+         * Convert a fixed length character array to a byte array.
+         *
+         * @param characters Character ta turn into UTF-8 encoded bytes
+         * @return UTF-8 byte encoding of string
+         */
+        public static byte[] toBytes(final char[] characters) {
+            final java.lang.String value = characters == null ? null : new java.lang.String(characters);
+            return stringToBytes(value);
+        }
+
+        /**
+         * Encodes a fixed length character array along with necessary metadata to reconstitute the value for encryption.
+         *
+         * @param value Character array  to encrypt
+         * @return Byte representation of the value and its metadata
+         */
+        public static byte[] encode(final char[] value) {
+            final ClientDataInfo info = ClientDataInfo.builder().type(ClientDataType.CHAR).isNull(value == null).build();
+            final byte[] bytes = (value == null) ? null : StandardCharsets.UTF_8.encode(CharBuffer.wrap(value)).array();
+            final int length = (value == null) ? 0 : TOTAL_METADATA_BYTES + bytes.length;
+            final ByteBuffer buffer = ByteBuffer.allocate(ClientDataInfo.BYTE_LENGTH + length)
+                    .put(info.encode());
+            if (value != null) {
+                buffer.putInt(value.length);
+                buffer.put(bytes);
+            }
+            return buffer.array();
+        }
+
+        /**
+         * Decodes a byte array into the original Char value.
+         *
+         * @param bytes Encoded value and metadata
+         * @return Char value
+         * @throws C3rRuntimeException if not enough bytes are in the encoded value or the data type is not Char
+         */
+        public static char[] decode(final byte[] bytes) {
+            final ByteBuffer buffer = ByteBuffer.wrap(bytes);
+            final ClientDataInfo info = stripClientDataInfo(buffer, ClientDataType.CHAR);
+            if (info.isNull()) {
+                return null;
+            }
+            try {
+                final int length = buffer.getInt();
+                final char[] value = StandardCharsets.UTF_8.decode(buffer).array();
+                if (value.length != length) {
+                    throw new C3rRuntimeException("Fixed length character array expected to be of length " + length + " but was " +
+                            value.length + ".");
+                }
+                checkBuffer(buffer);
+                return value;
+            } catch (BufferUnderflowException e) {
+                throw new C3rRuntimeException("Value could not be decoded, not enough bytes.", e);
+            }
+        }
+    }
+
+    /**
+     * Utility functions for converting a C3R Date to and from various representations. Date is relative to epoch.
      */
     public static final class Date {
         /**
@@ -263,14 +557,7 @@ public final class ValueConverter {
          * @throws C3rRuntimeException If the byte array is not the expected length
          */
         public static Integer fromBytes(final byte[] bytes) {
-            if (bytes == null) {
-                return null;
-            }
-            if (bytes.length != ClientDataType.INT_BYTE_SIZE) {
-                throw new C3rRuntimeException("DATE should be " + ClientDataType.INT_BYTE_SIZE + " in length but " + bytes.length +
-                        " found.");
-            }
-            return ByteBuffer.wrap(bytes).getInt();
+            return basicFromBytes(bytes, Integer.BYTES, ClientDataType.DATE, ByteBuffer::getInt);
         }
 
         /**
@@ -290,14 +577,7 @@ public final class ValueConverter {
          * @return Byte representation of the value and its metadata
          */
         public static byte[] encode(final Integer value) {
-            final ClientDataInfo info = ClientDataInfo.builder().type(ClientDataType.DATE).isNull(value == null).build();
-            final int length = (value == null) ? 0 : Integer.BYTES;
-            final ByteBuffer buffer =  ByteBuffer.allocate(ClientDataInfo.BYTE_LENGTH + length)
-                    .put(info.encode());
-            if (value != null) {
-                buffer.putInt(value);
-            }
-            return buffer.array();
+            return basicEncode(value, ClientDataType.DATE, Integer.BYTES, ByteBuffer::putInt);
         }
 
         /**
@@ -308,15 +588,130 @@ public final class ValueConverter {
          * @throws C3rRuntimeException if not enough bytes are in the encoded value or the data type is not Date
          */
         public static Integer decode(final byte[] bytes) {
-            final ByteBuffer buffer = ByteBuffer.wrap(bytes);
-            final ClientDataInfo info = stripClientDataInfo(buffer, ClientDataType.DATE);
-            if (info.isNull()) {
+            return basicDecode(bytes, ClientDataType.DATE, ByteBuffer::getInt);
+        }
+    }
+
+    /**
+     * Utility functions for converting a C3R Decimal to and from various representations.
+     */
+    public static final class Decimal {
+        /**
+         * How many bytes are needed to store the metadata needed to recreate the original value.
+         */
+        private static final int TOTAL_METADATA_BYTES = 2 * Integer.BYTES;
+
+        /**
+         * Takes a byte array and returns the fixed point number it represents. This is done by transforming the byte array into
+         * a string and then a {@code BigDecimal} value. Precision and scale may be smaller than they were originally since they
+         * are calculated using the digits present in the string value only.
+         *
+         * @param bytes Bytes representing a floating
+         * @return Fixed point number
+         */
+        public static BigDecimal fromBytes(final byte[] bytes) {
+            if (bytes == null) {
                 return null;
             }
+            final java.lang.String value = new java.lang.String(bytes, StandardCharsets.UTF_8);
+            return new BigDecimal(value);
+        }
+
+        /**
+         * Takes a fixed point number and returns the byte representation of the value. This is done by transforming the value
+         * into a string so the scale and precision before turning it into bytes may be larger than when decoded since the
+         * decoded value will only look at the digits present.
+         *
+         * @param decimal Fixed point number
+         * @return Byte representation of raw fixed point number
+         */
+        public static byte[] toBytes(final BigDecimal decimal) {
+            if (decimal == null) {
+                return null;
+            }
+            return decimal.toString().getBytes(StandardCharsets.UTF_8);
+        }
+
+        /**
+         * Encodes a decimal value, the precision and scale being used into a byte array so it can be recreated exactly later.
+         *
+         * <p>
+         * For a non-null value, the encoded byte array is of the form:<br/>
+         * Byte 1: {@link ClientDataInfo}<br/>
+         * Bytes 2-5: Precision<br/>
+         * Bytes 6-9: Scale<br/>
+         * Bytes 10+: Bytes representing fixed point number
+         * </p>
+         *
+         * <p>
+         * For a null value, the encoded byte array is of the form:<br/>
+         * Byte 1: {@code ClientDataInfo}<br/>
+         * Optionally:
+         * Bytes 2-5: Precision<br/>
+         * Bytes 6-9: Scale<br/>
+         * </p>
+         *
+         * @param value     Fixed point number
+         * @param precision How many digits are in the number
+         * @param scale     How many digits are to the right of the decimal point
+         * @return Byte array encoding all the information to recreate the decimal value
+         * @throws C3rIllegalArgumentException if precision and scale are missing for a non-null value
+         *                                     or have non-matching null status for a null value
+         */
+        public static byte[] encode(final BigDecimal value, final Integer precision, final Integer scale) {
+            final Object[] metadata = new Object[]{precision, scale};
+            if (metadataSpecifiedIncorrectly(value, metadata)) {
+                throw new C3rIllegalArgumentException("Precision and scale must both be specified unless value is null, " +
+                        "then they may optionally be null.");
+            }
+            final ClientDataInfo info = ClientDataInfo.builder().type(ClientDataType.DECIMAL).isNull(value == null).build();
+            final char[] plainString = (value == null) ? null : value.toPlainString().toCharArray();
+            int length = ClientDataInfo.BYTE_LENGTH;
+            length += getMetaDataByteLength(value, metadata, TOTAL_METADATA_BYTES, TOTAL_METADATA_BYTES);
+            length += (value == null) ? 0 : plainString.length * Character.BYTES;
+            final ByteBuffer buffer = ByteBuffer.allocate(length)
+                    .put(info.encode());
+            if (value != null) {
+                buffer.putInt(precision);
+                buffer.putInt(scale);
+                buffer.asCharBuffer().put(plainString);
+                return buffer.array();
+            } else if (precision != null && scale != null) {
+                buffer.putInt(precision);
+                buffer.putInt(scale);
+            }
+            return buffer.array();
+        }
+
+        /**
+         * Decodes a byte array into the original decimal value. Verifies valid values for UTC flag and units.
+         *
+         * @param bytes Encoded timestamp with information needed to recreate the correct value
+         * @return Information needed to create the value
+         * @throws C3rRuntimeException if not enough bytes are present or the bytes do not represent a {@code BigDecimal} value
+         */
+        public static ClientValueWithMetadata.Decimal decode(final byte[] bytes) {
+            final ByteBuffer buffer = ByteBuffer.wrap(bytes);
+            final ClientDataInfo info = stripClientDataInfo(buffer, ClientDataType.DECIMAL);
             try {
-                return buffer.getInt();
-            } catch (BufferUnderflowException e) {
-                throw new C3rRuntimeException("Value could not be decoded, not enough bytes.", e);
+                Integer precision = null;
+                Integer scale = null;
+                if (buffer.remaining() >= TOTAL_METADATA_BYTES) {
+                    precision = buffer.getInt();
+                    scale = buffer.getInt();
+                }
+                BigDecimal value = null;
+                if (!info.isNull()) {
+                    final java.lang.String stringValue = buffer.asCharBuffer().toString();
+                    buffer.position(buffer.limit());
+                    value = new BigDecimal(stringValue);
+                }
+                checkBuffer(buffer);
+                return new ClientValueWithMetadata.Decimal(value, precision, scale);
+            } catch (BufferUnderflowException bue) {
+                throw new C3rRuntimeException("Value could not be decoded, not enough bytes.", bue);
+            } catch (NumberFormatException nfe) {
+                throw new C3rRuntimeException("Value could not be decoded, invalid format.", nfe);
             }
         }
     }
@@ -334,12 +729,7 @@ public final class ValueConverter {
          * @throws C3rRuntimeException If the byte array is not the expected length
          */
         static java.lang.Double fromBytes(final byte[] bytes) {
-            if (bytes == null) {
-                return null;
-            } else if (bytes.length != java.lang.Double.BYTES) {
-                throw new C3rRuntimeException("Double values may only be " + java.lang.Double.BYTES + " bytes long.");
-            }
-            return ByteBuffer.wrap(bytes).getDouble();
+            return basicFromBytes(bytes, java.lang.Double.BYTES, ClientDataType.DOUBLE, ByteBuffer::getDouble);
         }
 
         /**
@@ -349,10 +739,7 @@ public final class ValueConverter {
          * @return Big-endian encoding of value
          */
         public static byte[] toBytes(final java.lang.Double value) {
-            if (value == null) {
-                return null;
-            }
-            return ByteBuffer.allocate(java.lang.Double.BYTES).putDouble(value).array();
+            return basicToBytes(value, java.lang.Double.BYTES, ByteBuffer::putDouble);
         }
 
         /**
@@ -362,14 +749,7 @@ public final class ValueConverter {
          * @return Byte representation of the value and its metadata
          */
         public static byte[] encode(final java.lang.Double value) {
-            final ClientDataInfo info = ClientDataInfo.builder().type(ClientDataType.DOUBLE).isNull(value == null).build();
-            final int length = (value == null) ? 0 : java.lang.Double.BYTES;
-            final ByteBuffer buffer =  ByteBuffer.allocate(ClientDataInfo.BYTE_LENGTH + length)
-                    .put(info.encode());
-            if (value != null) {
-                buffer.putDouble(value);
-            }
-            return buffer.array();
+            return basicEncode(value, ClientDataType.DOUBLE, java.lang.Double.BYTES, ByteBuffer::putDouble);
         }
 
         /**
@@ -380,16 +760,7 @@ public final class ValueConverter {
          * @throws C3rRuntimeException if not enough bytes are in the encoded value or the data type is not Double
          */
         public static java.lang.Double decode(final byte[] bytes) {
-            final ByteBuffer buffer = ByteBuffer.wrap(bytes);
-            final ClientDataInfo info = stripClientDataInfo(buffer, ClientDataType.DOUBLE);
-            if (info.isNull()) {
-                return null;
-            }
-            try {
-                return buffer.getDouble();
-            } catch (BufferUnderflowException e) {
-                throw new C3rRuntimeException("Value could not be decoded, not enough bytes.", e);
-            }
+            return basicDecode(bytes, ClientDataType.DOUBLE, ByteBuffer::getDouble);
         }
     }
 
@@ -406,12 +777,7 @@ public final class ValueConverter {
          * @throws C3rRuntimeException If the byte array is not the expected length
          */
         public static java.lang.Float fromBytes(final byte[] bytes) {
-            if (bytes == null) {
-                return null;
-            } else if (bytes.length != java.lang.Float.BYTES) {
-                throw new C3rRuntimeException("Float values may only be " + java.lang.Float.BYTES + " bytes long.");
-            }
-            return ByteBuffer.wrap(bytes).getFloat();
+            return basicFromBytes(bytes, java.lang.Float.BYTES, ClientDataType.FLOAT, ByteBuffer::getFloat);
         }
 
         /**
@@ -421,10 +787,7 @@ public final class ValueConverter {
          * @return Big-endian encoding of value
          */
         public static byte[] toBytes(final java.lang.Float value) {
-            if (value == null) {
-                return null;
-            }
-            return ByteBuffer.allocate(java.lang.Float.BYTES).putFloat(value).array();
+            return basicToBytes(value, java.lang.Float.BYTES, ByteBuffer::putFloat);
         }
 
         /**
@@ -434,14 +797,7 @@ public final class ValueConverter {
          * @return Byte representation of the value and its metadata
          */
         public static byte[] encode(final java.lang.Float value) {
-            final ClientDataInfo info = ClientDataInfo.builder().type(ClientDataType.FLOAT).isNull(value == null).build();
-            final int length = (value == null) ? 0 : java.lang.Float.BYTES;
-            final ByteBuffer buffer =  ByteBuffer.allocate(ClientDataInfo.BYTE_LENGTH + length)
-                    .put(info.encode());
-            if (value != null) {
-                buffer.putFloat(value);
-            }
-            return buffer.array();
+            return basicEncode(value, ClientDataType.FLOAT, java.lang.Float.BYTES, ByteBuffer::putFloat);
         }
 
         /**
@@ -452,16 +808,7 @@ public final class ValueConverter {
          * @throws C3rRuntimeException if not enough bytes are in the encoded value or the data type is not Float
          */
         public static java.lang.Float decode(final byte[] bytes) {
-            final ByteBuffer buffer = ByteBuffer.wrap(bytes);
-            final ClientDataInfo info = stripClientDataInfo(buffer, ClientDataType.FLOAT);
-            if (info.isNull()) {
-                return null;
-            }
-            try {
-                return buffer.getFloat();
-            } catch (BufferUnderflowException e) {
-                throw new C3rRuntimeException("Value could not be decoded, not enough bytes.", e);
-            }
+            return basicDecode(bytes, ClientDataType.FLOAT, ByteBuffer::getFloat);
         }
     }
 
@@ -478,16 +825,7 @@ public final class ValueConverter {
          * @throws C3rRuntimeException If the byte array is more than the max length
          */
         public static Integer fromBytes(@Nullable final byte[] bytes) {
-            if (bytes == null) {
-                return null;
-            } else if (bytes.length > ClientDataType.INT_BYTE_SIZE) {
-                throw new C3rRuntimeException("Integer values must be " + ClientDataType.INT_BYTE_SIZE + " bytes or less.");
-            }
-            try {
-                return new BigInteger(bytes).intValueExact();
-            } catch (ArithmeticException e) {
-                throw new C3rRuntimeException("Value out of range of an Int.");
-            }
+            return integralFromBytes(bytes, ClientDataType.INT, BigInteger::intValueExact);
         }
 
         /**
@@ -497,10 +835,7 @@ public final class ValueConverter {
          * @return Big-endian byte encoding of value
          */
         public static byte[] toBytes(final Integer value) {
-            if (value == null) {
-                return null;
-            }
-            return ByteBuffer.allocate(ClientDataType.INT_BYTE_SIZE).putInt(value).array();
+            return basicToBytes(value, ClientDataType.INT_BYTE_SIZE, ByteBuffer::putInt);
         }
 
         /**
@@ -510,14 +845,7 @@ public final class ValueConverter {
          * @return Byte representation of the value and its metadata
          */
         public static byte[] encode(final Integer value) {
-            final ClientDataInfo info = ClientDataInfo.builder().type(ClientDataType.INT).isNull(value == null).build();
-            final int length = (value == null) ? 0 : ClientDataType.INT_BYTE_SIZE;
-            final ByteBuffer buffer =  ByteBuffer.allocate(ClientDataInfo.BYTE_LENGTH + length)
-                    .put(info.encode());
-            if (value != null) {
-                buffer.putInt(value);
-            }
-            return buffer.array();
+            return basicEncode(value, ClientDataType.INT, ClientDataType.INT_BYTE_SIZE, ByteBuffer::putInt);
         }
 
         /**
@@ -528,16 +856,7 @@ public final class ValueConverter {
          * @throws C3rRuntimeException if not enough bytes are in the encoded value or the data type is not Int
          */
         public static Integer decode(final byte[] bytes) {
-            final ByteBuffer buffer = ByteBuffer.wrap(bytes);
-            final ClientDataInfo info = stripClientDataInfo(buffer, ClientDataType.INT);
-            if (info.isNull()) {
-                return null;
-            }
-            try {
-                return buffer.getInt();
-            } catch (BufferUnderflowException e) {
-                throw new C3rRuntimeException("Value could not be decoded, not enough bytes.", e);
-            }
+            return basicDecode(bytes, ClientDataType.INT, ByteBuffer::getInt);
         }
     }
 
@@ -554,16 +873,7 @@ public final class ValueConverter {
          * @throws C3rRuntimeException If the byte array is more than the max length
          */
         public static Short fromBytes(@Nullable final byte[] bytes) {
-            if (bytes == null) {
-                return null;
-            } else if (bytes.length > ClientDataType.SMALLINT_BYTE_SIZE) {
-                throw new C3rRuntimeException("Integer values must be " + ClientDataType.INT_BYTE_SIZE + " bytes or less.");
-            }
-            try {
-                return new BigInteger(bytes).shortValueExact();
-            } catch (ArithmeticException e) {
-                throw new C3rRuntimeException("Value out of range of SmallInt.", e);
-            }
+            return integralFromBytes(bytes, ClientDataType.SMALLINT, BigInteger::shortValueExact);
         }
 
         /**
@@ -573,10 +883,7 @@ public final class ValueConverter {
          * @return Big-endian byte encoding of value
          */
         public static byte[] toBytes(final Short value) {
-            if (value == null) {
-                return null;
-            }
-            return ByteBuffer.allocate(ClientDataType.SMALLINT_BYTE_SIZE).putShort(value).array();
+            return basicToBytes(value, ClientDataType.SMALLINT_BYTE_SIZE, ByteBuffer::putShort);
         }
 
         /**
@@ -586,14 +893,7 @@ public final class ValueConverter {
          * @return Byte representation of the value and its metadata
          */
         public static byte[] encode(final Short value) {
-            final ClientDataInfo info = ClientDataInfo.builder().type(ClientDataType.SMALLINT).isNull(value == null).build();
-            final int length = (value == null) ? 0 : ClientDataType.SMALLINT_BYTE_SIZE;
-            final ByteBuffer buffer =  ByteBuffer.allocate(ClientDataInfo.BYTE_LENGTH + length)
-                    .put(info.encode());
-            if (value != null) {
-                buffer.putShort(value);
-            }
-            return buffer.array();
+            return basicEncode(value, ClientDataType.SMALLINT, ClientDataType.SMALLINT_BYTE_SIZE, ByteBuffer::putShort);
         }
 
         /**
@@ -604,16 +904,7 @@ public final class ValueConverter {
          * @throws C3rRuntimeException if not enough bytes are in the encoded value or the data type is not SmallInt
          */
         public static Short decode(final byte[] bytes) {
-            final ByteBuffer buffer = ByteBuffer.wrap(bytes);
-            final ClientDataInfo info = stripClientDataInfo(buffer, ClientDataType.SMALLINT);
-            if (info.isNull()) {
-                return null;
-            }
-            try {
-                return buffer.getShort();
-            } catch (BufferUnderflowException e) {
-                throw new C3rRuntimeException("Value could not be decoded, not enough bytes.", e);
-            }
+            return basicDecode(bytes, ClientDataType.SMALLINT, ByteBuffer::getShort);
         }
     }
 
@@ -628,23 +919,17 @@ public final class ValueConverter {
          * @return UTF-8 string generated from bytes
          */
         public static java.lang.String fromBytes(final byte[] bytes) {
-            if (bytes == null) {
-                return null;
-            }
-            return StandardCharsets.UTF_8.decode(ByteBuffer.wrap(bytes)).toString();
+            return stringFromBytes(bytes);
         }
 
         /**
          * Convert a string to the UTF-8 bytes that represent its value.
          *
-         * @param value String to conver to bytes
+         * @param value String to convert to bytes
          * @return UTF-8 byte representation
          */
         public static byte[] toBytes(final java.lang.String value) {
-            if (value == null) {
-                return null;
-            }
-            return value.getBytes(StandardCharsets.UTF_8);
+            return stringToBytes(value);
         }
 
         /**
@@ -654,15 +939,9 @@ public final class ValueConverter {
          * @return Byte representation of the value and its metadata
          */
         public static byte[] encode(final java.lang.String value) {
-            final ClientDataInfo info = ClientDataInfo.builder().type(ClientDataType.STRING).isNull(value == null).build();
-            final byte[] bytes = toBytes(value);
-            final int length = (bytes == null) ? 0 : bytes.length;
-            final ByteBuffer buffer =  ByteBuffer.allocate(ClientDataInfo.BYTE_LENGTH + length)
-                    .put(info.encode());
-            if (bytes != null) {
-                buffer.put(bytes);
-            }
-            return buffer.array();
+            final byte[] asBytes = toBytes(value);
+            final int size = asBytes == null ? 0 : asBytes.length;
+            return basicEncode(asBytes, ClientDataType.STRING, size, ByteBuffer::put);
         }
 
         /**
@@ -681,7 +960,245 @@ public final class ValueConverter {
             try {
                 final byte[] strBuffer = new byte[bytes.length - ClientDataInfo.BYTE_LENGTH];
                 buffer.get(strBuffer, 0, strBuffer.length);
+                checkBuffer(buffer);
                 return fromBytes(strBuffer);
+            } catch (BufferUnderflowException e) {
+                throw new C3rRuntimeException("Value could not be decoded, not enough bytes.", e);
+            }
+        }
+    }
+
+    /**
+     * Utility functions for converting a C3R Timestamp to and from various representations. Timestamps are relative to epoch.
+     */
+    public static final class Timestamp {
+        /**
+         * Number of bytes the metadata uses.
+         */
+        private static final int TOTAL_METADATA_BYTES = Byte.BYTES + Integer.BYTES;
+
+        /**
+         * Takes a byte array representing a {@code BigInteger} value and converts it back to a {@code BigInteger} value
+         * which is a timestamp value in nanoseconds.
+         *
+         * @param bytes Byte array used by a {@code BigInteger} to store a nanosecond-based timestamp
+         * @return A timestamp relative to epoch in nanoseconds
+         */
+        public static BigInteger fromBytes(final byte[] bytes) {
+            if (bytes == null) {
+                return null;
+            }
+            return new BigInteger(bytes);
+        }
+
+        /**
+         * Converts a timestamp into its raw byte representation. All values are converted to nanoseconds as unit information
+         * is not conserved and using nanoseconds prevents loss of information.
+         *
+         * @param value Timestamp value
+         * @param units What unit of time the value is in
+         * @return Bytes from a {@code BigInteger} that represents the timestamp in nanoseconds
+         */
+        public static byte[] toBytes(final Long value, final Units.Seconds units) {
+            if (value == null) {
+                return null;
+            }
+            final BigInteger asNanos = Units.Seconds.convert(BigInteger.valueOf(value), units, Units.Seconds.NANOS);
+            return asNanos.toByteArray();
+        }
+
+        /**
+         * Takes a timestamp value plus if the value is in UTC time and unit for the value and creates a byte array with
+         * all the information needed to recreate the value.
+         *
+         * <p>
+         * For a non-null value, the encoded byte array is of the form:<br/>
+         * Byte 1: {@link ClientDataInfo}<br/>
+         * Byte 2: Whether the timestamp is in UTC<br/>
+         * Bytes 3-6: Unit of time for the value<br/>
+         * Bytes 7-14: Timestamp value
+         * </p>
+         *
+         * <p>
+         * For a null value, the encoded byte array is of the form:<br/>
+         * Byte 1: {@code ClientDataInfo}<br/>
+         * Optionally:
+         * Byte 2: Whether the timestamp is in UTC<br/>
+         * Bytes 3-6: Unit of time for the value<br/>
+         * </p>
+         *
+         * @param value Timestamp value
+         * @param isUtc If the timestamp is in UTC time or not
+         * @param unit  What time unit the value is in
+         * @return Byte array with all information needed to reconstruct the value as intended
+         * @throws C3rIllegalArgumentException if the UTC or unit information is missing for a non-null value
+         *                                     or only one value is specified when value is null
+         */
+        public static byte[] encode(final Long value, final java.lang.Boolean isUtc, final Units.Seconds unit) {
+            final Object[] metadata = new Object[]{isUtc, unit};
+            if (metadataSpecifiedIncorrectly(value, metadata)) {
+                throw new C3rIllegalArgumentException("isUtc and unit must all be specified " +
+                        "unless value is null then they may optionally be null.");
+            }
+            final ClientDataInfo info = ClientDataInfo.builder().type(ClientDataType.TIMESTAMP).isNull(value == null).build();
+            int length = ClientDataInfo.BYTE_LENGTH;
+            length += getMetaDataByteLength(value, metadata, TOTAL_METADATA_BYTES, TOTAL_METADATA_BYTES);
+            length += (value == null) ? 0 : Long.BYTES;
+            final ByteBuffer buffer = ByteBuffer.allocate(length).put(info.encode());
+            if (buffer.remaining() >= TOTAL_METADATA_BYTES) {
+                buffer.put(getBytesFromBoolean(isUtc));
+                buffer.putInt(unit.ordinal());
+            }
+            if (!info.isNull()) {
+                buffer.putLong(value);
+            }
+            return buffer.array();
+        }
+
+        /**
+         * Decodes a byte array into the original timestamp value. Verifies valid values for UTC flag and units.
+         *
+         * @param bytes Encoded timestamp with information needed to recreate the correct value
+         * @return Information needed to create the value
+         * @throws C3rRuntimeException if not enough bytes are present, the wrong type is found or metadata fails verification
+         */
+        public static ClientValueWithMetadata.Timestamp decode(final byte[] bytes) {
+            final ByteBuffer buffer = ByteBuffer.wrap(bytes);
+            final ClientDataInfo info = stripClientDataInfo(buffer, ClientDataType.TIMESTAMP);
+            try {
+                java.lang.Boolean isUtc = null;
+                Units.Seconds unit = null;
+                if (buffer.remaining() >= TOTAL_METADATA_BYTES) {
+                    isUtc = getBooleanFromByte(buffer.get());
+                    final int index = buffer.getInt();
+                    if (index >= Units.Seconds.values().length) {
+                        throw new C3rRuntimeException("Could not decode unit for timestamp.");
+                    }
+                    unit = Units.Seconds.values()[index];
+                }
+                Long value = null;
+                if (!info.isNull()) {
+                    value = buffer.getLong();
+                }
+                checkBuffer(buffer);
+                return new ClientValueWithMetadata.Timestamp(value, isUtc, unit);
+            } catch (BufferUnderflowException e) {
+                throw new C3rRuntimeException("Value could not be decoded, not enough bytes.", e);
+            }
+        }
+    }
+
+    /**
+     * Utility functions for converting a C3R Varchar to and from various representations.
+     */
+    public static final class Varchar {
+        /**
+         * How many bytes are needed to store the metadata for a non-null value.
+         */
+        private static final int TOTAL_METADATA_BYTES = 2 * Integer.BYTES;
+
+        /**
+         * How many bytes are needed to store the metadata for a null value.
+         */
+        private static final int TOTAL_NULL_VALUE_METADATA_BYTES = Integer.BYTES;
+
+        /**
+         * Convert the byte array into a UTF-8 variable length character array.
+         *
+         * @param bytes Bytes representing a variable length character array
+         * @return Variable length character array
+         */
+        public static java.lang.String fromBytes(final byte[] bytes) {
+            return stringFromBytes(bytes);
+        }
+
+        /**
+         * Converts a variable length character array into its UTF-8 byte representation.
+         *
+         * @param value Variable length character array
+         * @return Byte array that holds the UTF-8 encoding of the character array
+         */
+        public static byte[] toBytes(final java.lang.String value) {
+            return stringToBytes(value);
+        }
+
+        /**
+         * Takes a variable length character array value and creates a byte array with all the information needed to recreate the value.
+         *
+         * <p>
+         * For a non-null value, the encoded byte array is of the form:<br/>
+         * Byte 1: {@link ClientDataInfo}<br/>
+         * Bytes 2-5: Maximum length the array can be<br/>
+         * Bytes 6-9: Length of the string (Used to validate data was properly decoded)<br/>
+         * Bytes 10+: Bytes for the UTF-8 formatted version of the variable length character array
+         * </p>
+         *
+         * <p>
+         * For a null value, the encoded byte array is of the form:<br/>
+         * Byte 1: {@code ClientDataInfo}<br/>
+         * Optionally:<br/>
+         * Bytes 2-5: Maximum length the array can be
+         * </p>
+         *
+         * @param value     Character array value
+         * @param maxLength Longest length the variable length character array can be
+         * @return Byte array with all information needed to reconstruct the value as intended
+         * @throws C3rIllegalArgumentException if the value is longer than the allowed maximum length or the maximum length is unspecified
+         */
+        public static byte[] encode(final java.lang.String value, final Integer maxLength) {
+            final Object[] metadata = new Object[]{maxLength};
+            if (metadataSpecifiedIncorrectly(value, metadata)) {
+                throw new C3rIllegalArgumentException("Max length must be specified unless value is null.");
+            }
+            if (value != null && value.length() > maxLength) {
+                throw new C3rIllegalArgumentException("Value is greater than allowed maximum length for varchar field.");
+            }
+            final ClientDataInfo info = ClientDataInfo.builder().type(ClientDataType.VARCHAR).isNull(value == null).build();
+            int length = getMetaDataByteLength(value, metadata, TOTAL_METADATA_BYTES, TOTAL_NULL_VALUE_METADATA_BYTES);
+            length += (value == null) ? 0 : value.getBytes(StandardCharsets.UTF_8).length;
+            final ByteBuffer buffer = ByteBuffer.allocate(ClientDataInfo.BYTE_LENGTH + length)
+                    .put(info.encode());
+            if (value != null) {
+                buffer.putInt(maxLength);
+                final byte[] bytes = value.getBytes(StandardCharsets.UTF_8);
+                buffer.putInt(bytes.length);
+                buffer.put(bytes);
+            } else if (maxLength != null) {
+                buffer.putInt(maxLength);
+            }
+            return buffer.array();
+        }
+
+        /**
+         * Decodes a byte array into the original variable length character array. Verifies the string is of the expected length and
+         * less than or equal to the maximum length.
+         *
+         * @param bytes Encoded variable length character array with information needed to recreate the correct value
+         * @return Information needed to create the value
+         * @throws C3rRuntimeException if not enough bytes are present, the wrong type is found or the length checks fail
+         */
+        public static ClientValueWithMetadata.Varchar decode(final byte[] bytes) {
+            final ByteBuffer buffer = ByteBuffer.wrap(bytes);
+            final ClientDataInfo info = stripClientDataInfo(buffer, ClientDataType.VARCHAR);
+            try {
+                Integer maxLength = null;
+                if (buffer.remaining() >= TOTAL_NULL_VALUE_METADATA_BYTES) {
+                    maxLength = buffer.getInt();
+                }
+                java.lang.String value = null;
+                if (!info.isNull()) {
+                    final int length = buffer.getInt();
+                    value = StandardCharsets.UTF_8.decode(buffer).toString();
+                    if (value.length() != length) {
+                        throw new C3rRuntimeException("Variable length character array expected to be of length " + length + " but was " +
+                                value.length() + ".");
+                    } else if (value.length() > maxLength) {
+                        throw new C3rRuntimeException("Varchar expected to be " + maxLength + " characters long at most but was " +
+                                value.length() + " characters long.");
+                    }
+                }
+                checkBuffer(buffer);
+                return new ClientValueWithMetadata.Varchar(value, maxLength);
             } catch (BufferUnderflowException e) {
                 throw new C3rRuntimeException("Value could not be decoded, not enough bytes.", e);
             }

--- a/c3r-sdk-core/src/test/java/com/amazonaws/c3r/data/ClientDataTypeMetadataTest.java
+++ b/c3r-sdk-core/src/test/java/com/amazonaws/c3r/data/ClientDataTypeMetadataTest.java
@@ -1,0 +1,95 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.amazonaws.c3r.data;
+
+import com.amazonaws.c3r.exception.C3rIllegalArgumentException;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class ClientDataTypeMetadataTest {
+    @Test
+    public void decimalConstructionTest() {
+        final Integer scale = 2;
+        final Integer precision = 3;
+        final BigDecimal value = BigDecimal.valueOf(101, scale);
+
+        final ClientValueWithMetadata.Decimal allSpecified = new ClientValueWithMetadata.Decimal(value, precision, scale);
+        assertEquals(scale, allSpecified.getScale());
+        assertEquals(precision, allSpecified.getPrecision());
+        assertEquals(value, allSpecified.getValue());
+
+        final ClientValueWithMetadata.Decimal valueMissing = new ClientValueWithMetadata.Decimal(null, precision, scale);
+        assertEquals(scale, valueMissing.getScale());
+        assertEquals(precision, valueMissing.getPrecision());
+        assertNull(valueMissing.getValue());
+
+        assertThrows(C3rIllegalArgumentException.class, () -> new ClientValueWithMetadata.Decimal(value, null, scale));
+        assertThrows(C3rIllegalArgumentException.class, () -> new ClientValueWithMetadata.Decimal(value, precision, null));
+        assertThrows(C3rIllegalArgumentException.class, () -> new ClientValueWithMetadata.Decimal(null, null, scale));
+
+        assertThrows(C3rIllegalArgumentException.class, () -> new ClientValueWithMetadata.Decimal(null, precision, null));
+        assertThrows(C3rIllegalArgumentException.class, () -> new ClientValueWithMetadata.Decimal(value, null, null));
+
+        final ClientValueWithMetadata.Decimal allNull = new ClientValueWithMetadata.Decimal(null, null, null);
+        assertNull(allNull.getScale());
+        assertNull(allNull.getPrecision());
+        assertNull(allNull.getValue());
+    }
+
+    @Test
+    public void timestampConstructionTest() {
+        final Long time = 100L;
+        final Boolean isUtc = true;
+        final Units.Seconds units = Units.Seconds.MILLIS;
+
+        final ClientValueWithMetadata.Timestamp allSpecified = new ClientValueWithMetadata.Timestamp(time, isUtc, units);
+        assertEquals(time, allSpecified.getValue());
+        assertEquals(isUtc, allSpecified.getIsUtc());
+        assertEquals(units, allSpecified.getUnit());
+
+        assertThrows(C3rIllegalArgumentException.class, () -> new ClientValueWithMetadata.Timestamp(time, null, units));
+        assertThrows(C3rIllegalArgumentException.class, () -> new ClientValueWithMetadata.Timestamp(time, isUtc, null));
+        assertThrows(C3rIllegalArgumentException.class, () -> new ClientValueWithMetadata.Timestamp(time, null, null));
+
+        assertThrows(C3rIllegalArgumentException.class, () -> new ClientValueWithMetadata.Timestamp(null, null, units));
+        assertThrows(C3rIllegalArgumentException.class, () -> new ClientValueWithMetadata.Timestamp(null, isUtc, null));
+
+        final ClientValueWithMetadata.Timestamp nullValueWithMetadata = new ClientValueWithMetadata.Timestamp(null, isUtc, units);
+        assertNull(nullValueWithMetadata.getValue());
+        assertEquals(isUtc, nullValueWithMetadata.getIsUtc());
+        assertEquals(units, nullValueWithMetadata.getUnit());
+
+        final ClientValueWithMetadata.Timestamp nullValueWithoutMetadata = new ClientValueWithMetadata.Timestamp(null, null, null);
+        assertNull(nullValueWithoutMetadata.getValue());
+        assertNull(nullValueWithoutMetadata.getIsUtc());
+        assertNull(nullValueWithoutMetadata.getUnit());
+    }
+
+    @Test
+    public void varcharConstructionTest() {
+        final String value = "hello";
+        final String longValue = "hello world!";
+        final Integer maxLength = 10;
+
+        final ClientValueWithMetadata.Varchar allSpecified = new ClientValueWithMetadata.Varchar(value, maxLength);
+        assertEquals(value, allSpecified.getValue());
+        assertEquals(maxLength, allSpecified.getMaxLength());
+
+        final ClientValueWithMetadata.Varchar nullValue = new ClientValueWithMetadata.Varchar(null, maxLength);
+        assertNull(nullValue.getValue());
+        assertEquals(maxLength, nullValue.getMaxLength());
+
+        final ClientValueWithMetadata.Varchar allNull = new ClientValueWithMetadata.Varchar(null, null);
+        assertNull(allNull.getValue());
+        assertNull(allNull.getMaxLength());
+
+        assertThrows(C3rIllegalArgumentException.class, () -> new ClientValueWithMetadata.Varchar(value, null));
+        assertThrows(C3rIllegalArgumentException.class, () -> new ClientValueWithMetadata.Varchar(longValue, maxLength));
+    }
+}

--- a/c3r-sdk-core/src/test/java/com/amazonaws/c3r/data/UnitsTest.java
+++ b/c3r-sdk-core/src/test/java/com/amazonaws/c3r/data/UnitsTest.java
@@ -1,0 +1,42 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.amazonaws.c3r.data;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.math.BigInteger;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class UnitsTest {
+    private static Stream<Arguments> secondConversions() {
+        return Stream.of(
+                Arguments.of(2L, 2L, Units.Seconds.MILLIS, Units.Seconds.MILLIS),
+                Arguments.of(2L, 2000L, Units.Seconds.MILLIS, Units.Seconds.MICROS),
+                Arguments.of(2L, 2000000L, Units.Seconds.MILLIS, Units.Seconds.NANOS),
+                Arguments.of(3000L, 3L, Units.Seconds.MICROS, Units.Seconds.MILLIS),
+                Arguments.of(3L, 3L, Units.Seconds.MICROS, Units.Seconds.MICROS),
+                Arguments.of(3L, 3000L, Units.Seconds.MICROS, Units.Seconds.NANOS),
+                Arguments.of(4000000L, 4L, Units.Seconds.NANOS, Units.Seconds.MILLIS),
+                Arguments.of(4000L, 4L, Units.Seconds.NANOS, Units.Seconds.MICROS),
+                Arguments.of(4L, 4L, Units.Seconds.NANOS, Units.Seconds.NANOS)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("secondConversions")
+    public void secondConversionTest(final Long value, final Long result, final Units.Seconds from, final Units.Seconds to) {
+        assertEquals(BigInteger.valueOf(result), Units.Seconds.convert(BigInteger.valueOf(value), from, to));
+    }
+
+    @Test
+    public void nullValueSecondConversionTest() {
+        assertNull(Units.Seconds.convert(null, Units.Seconds.MICROS, Units.Seconds.MICROS));
+    }
+}

--- a/c3r-sdk-core/src/test/java/com/amazonaws/c3r/data/ValueConverterTest.java
+++ b/c3r-sdk-core/src/test/java/com/amazonaws/c3r/data/ValueConverterTest.java
@@ -8,6 +8,7 @@ import com.amazonaws.c3r.config.ColumnInsight;
 import com.amazonaws.c3r.config.ColumnSchema;
 import com.amazonaws.c3r.config.ColumnType;
 import com.amazonaws.c3r.config.Pad;
+import com.amazonaws.c3r.exception.C3rIllegalArgumentException;
 import com.amazonaws.c3r.exception.C3rRuntimeException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -16,21 +17,24 @@ import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentMatchers;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.math.MathContext;
 import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
-import static com.amazonaws.c3r.data.ClientDataType.BIGINT_BYTE_SIZE;
-import static com.amazonaws.c3r.data.ClientDataType.INT_BYTE_SIZE;
-import static com.amazonaws.c3r.data.ClientDataType.SMALLINT_BYTE_SIZE;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
 public class ValueConverterTest {
@@ -50,7 +54,7 @@ public class ValueConverterTest {
         final Value value = org.mockito.Mockito.mock(Value.class);
         when(value.getClientDataType()).thenReturn(type);
         when(value.getBytesAs(ArgumentMatchers.eq(ClientDataType.BIGINT)))
-                .thenReturn(ByteBuffer.allocate(BIGINT_BYTE_SIZE).putLong(2L).array());
+                .thenReturn(ByteBuffer.allocate(ClientDataType.BIGINT_BYTE_SIZE).putLong(2L).array());
         when(value.getBytesAs(ArgumentMatchers.eq(ClientDataType.STRING))).thenReturn("hello".getBytes(StandardCharsets.UTF_8));
         when(value.getBytes()).thenReturn(testVal);
         assertEquals(value.getBytes(), ValueConverter.getBytesForColumn(value, CLEARTEXT_COLUMN_INSIGHT.getType()));
@@ -63,7 +67,7 @@ public class ValueConverterTest {
         final Value value = org.mockito.Mockito.mock(Value.class);
         when(value.getClientDataType()).thenReturn(type);
         when(value.getBytesAs(ArgumentMatchers.eq(ClientDataType.BIGINT)))
-                .thenReturn(ByteBuffer.allocate(BIGINT_BYTE_SIZE).putLong(2L).array());
+                .thenReturn(ByteBuffer.allocate(ClientDataType.BIGINT_BYTE_SIZE).putLong(2L).array());
         when(value.getBytesAs(ArgumentMatchers.eq(ClientDataType.STRING))).thenReturn("hello".getBytes(StandardCharsets.UTF_8));
         when(value.getBytes()).thenReturn(testVal);
         assertEquals(value.getBytes(), ValueConverter.getBytesForColumn(value, SEALED_COLUMN_INSIGHT.getType()));
@@ -86,10 +90,11 @@ public class ValueConverterTest {
         final Value value = org.mockito.Mockito.mock(Value.class);
         when(value.getClientDataType()).thenReturn(type);
         when(value.getBytesAs(ArgumentMatchers.eq(ClientDataType.BIGINT)))
-                .thenReturn(ByteBuffer.allocate(BIGINT_BYTE_SIZE).putLong(2L).array());
+                .thenReturn(ByteBuffer.allocate(ClientDataType.BIGINT_BYTE_SIZE).putLong(2L).array());
         when(value.getBytes()).thenReturn(
                 type == ClientDataType.BIGINT ?
-                        ByteBuffer.allocate(BIGINT_BYTE_SIZE).putLong(2L).array() : ByteBuffer.allocate(INT_BYTE_SIZE).putInt(2).array()
+                        ByteBuffer.allocate(ClientDataType.BIGINT_BYTE_SIZE).putLong(2L).array() :
+                        ByteBuffer.allocate(com.amazonaws.c3r.data.ClientDataType.INT_BYTE_SIZE).putInt(2).array()
         );
         if (type == ClientDataType.BIGINT) {
             assertArrayEquals(value.getBytes(), ValueConverter.getBytesForColumn(value, FINGERPRINT_COLUMN_INSIGHT.getType()));
@@ -107,9 +112,10 @@ public class ValueConverterTest {
         assertNull(ValueConverter.BigInt.toBytes((Integer) null));
         assertNull(ValueConverter.BigInt.toBytes((Long) null));
         // BigInt values can only be at most BIGINT_BYTE_LEN in length
-        final byte[] tooFewBytes = new byte[BIGINT_BYTE_SIZE - 1];
-        final byte[] exactBytes = new byte[BIGINT_BYTE_SIZE];
-        final byte[] tooManyBytes = new byte[BIGINT_BYTE_SIZE + 1];
+        final byte[] tooFewBytes = new byte[ClientDataType.BIGINT_BYTE_SIZE - 1];
+        final byte[] exactBytes = new byte[ClientDataType.BIGINT_BYTE_SIZE];
+        final byte[] tooManyBytes = new byte[ClientDataType.BIGINT_BYTE_SIZE + 1];
+        Arrays.fill(tooManyBytes, (byte) 1);
         assertDoesNotThrow(() -> ValueConverter.BigInt.fromBytes(tooFewBytes));
         assertDoesNotThrow(() -> ValueConverter.BigInt.fromBytes(exactBytes));
         assertThrows(C3rRuntimeException.class, () -> ValueConverter.BigInt.fromBytes(tooManyBytes));
@@ -123,8 +129,16 @@ public class ValueConverterTest {
         assertEquals(
                 false,
                 ValueConverter.Boolean.fromBytes(ValueConverter.Boolean.toBytes(false)));
+        assertNull(ValueConverter.Boolean.toBytes(null));
         assertNull(ValueConverter.Boolean.fromBytes(null));
-        assertNull(ValueConverter.Boolean.fromBytes(null));
+    }
+
+    @Test
+    public void charBytesTest() {
+        final char[] value = new char[]{'A', 'B', 'C'};
+        assertArrayEquals(value, ValueConverter.Char.fromBytes(ValueConverter.Char.toBytes(value)));
+        assertNull(ValueConverter.Char.toBytes(null));
+        assertNull(ValueConverter.Char.fromBytes(null));
     }
 
     @Test
@@ -142,19 +156,10 @@ public class ValueConverterTest {
     }
 
     @Test
-    public void floatBytesTest() {
-        assertEquals(
-                (float) 42.0,
-                ValueConverter.Float.fromBytes(ValueConverter.Float.toBytes((float) 42.0)));
-        assertNull(ValueConverter.Float.fromBytes(null));
-        assertNull(ValueConverter.Float.toBytes(null));
-        // Floats must be exactly Float.BYTES long
-        final byte[] tooFewBytes = new byte[Float.BYTES - 1];
-        final byte[] exactBytes = new byte[Float.BYTES];
-        final byte[] tooManyBytes = new byte[Float.BYTES + 1];
-        assertThrows(C3rRuntimeException.class, () -> ValueConverter.Float.fromBytes(tooFewBytes));
-        assertDoesNotThrow(() -> ValueConverter.Float.fromBytes(exactBytes));
-        assertThrows(C3rRuntimeException.class, () -> ValueConverter.Float.fromBytes(tooManyBytes));
+    public void decimalBytesTest() {
+        assertEquals(BigDecimal.TEN, ValueConverter.Decimal.fromBytes(ValueConverter.Decimal.toBytes(BigDecimal.TEN)));
+        assertNull(ValueConverter.Decimal.fromBytes(null));
+        assertNull(ValueConverter.Decimal.toBytes(null));
     }
 
     @Test
@@ -174,6 +179,22 @@ public class ValueConverterTest {
     }
 
     @Test
+    public void floatBytesTest() {
+        assertEquals(
+                (float) 42.0,
+                ValueConverter.Float.fromBytes(ValueConverter.Float.toBytes((float) 42.0)));
+        assertNull(ValueConverter.Float.fromBytes(null));
+        assertNull(ValueConverter.Float.toBytes(null));
+        // Floats must be exactly Float.BYTES long
+        final byte[] tooFewBytes = new byte[Float.BYTES - 1];
+        final byte[] exactBytes = new byte[Float.BYTES];
+        final byte[] tooManyBytes = new byte[Float.BYTES + 1];
+        assertThrows(C3rRuntimeException.class, () -> ValueConverter.Float.fromBytes(tooFewBytes));
+        assertDoesNotThrow(() -> ValueConverter.Float.fromBytes(exactBytes));
+        assertThrows(C3rRuntimeException.class, () -> ValueConverter.Float.fromBytes(tooManyBytes));
+    }
+
+    @Test
     public void intBytesTest() {
         assertEquals(
                 42,
@@ -181,9 +202,10 @@ public class ValueConverterTest {
         assertNull(ValueConverter.Int.fromBytes(null));
         assertNull(ValueConverter.Int.toBytes(null));
         // Integer values can be at most INT_BYTES_LONG long
-        final byte[] lessBytes = new byte[INT_BYTE_SIZE - 1];
-        final byte[] exactBytes = new byte[INT_BYTE_SIZE];
-        final byte[] tooManyBytes = new byte[INT_BYTE_SIZE + 1];
+        final byte[] lessBytes = new byte[com.amazonaws.c3r.data.ClientDataType.INT_BYTE_SIZE - 1];
+        final byte[] exactBytes = new byte[com.amazonaws.c3r.data.ClientDataType.INT_BYTE_SIZE];
+        final byte[] tooManyBytes = new byte[com.amazonaws.c3r.data.ClientDataType.INT_BYTE_SIZE + 1];
+        Arrays.fill(tooManyBytes, (byte) 9);
         assertDoesNotThrow(() -> ValueConverter.Int.fromBytes(lessBytes));
         assertDoesNotThrow(() -> ValueConverter.Int.fromBytes(exactBytes));
         assertThrows(C3rRuntimeException.class, () -> ValueConverter.Int.fromBytes(tooManyBytes));
@@ -198,9 +220,10 @@ public class ValueConverterTest {
         assertNull(ValueConverter.BigInt.toBytes((Integer) null));
         assertNull(ValueConverter.BigInt.toBytes((Long) null));
         // SmallInt values can only be at most BIGINT_BYTE_LEN in length
-        final byte[] tooFewBytes = new byte[SMALLINT_BYTE_SIZE - 1];
-        final byte[] exactBytes = new byte[SMALLINT_BYTE_SIZE];
-        final byte[] tooManyBytes = new byte[SMALLINT_BYTE_SIZE + 1];
+        final byte[] tooFewBytes = new byte[com.amazonaws.c3r.data.ClientDataType.SMALLINT_BYTE_SIZE - 1];
+        final byte[] exactBytes = new byte[com.amazonaws.c3r.data.ClientDataType.SMALLINT_BYTE_SIZE];
+        final byte[] tooManyBytes = new byte[com.amazonaws.c3r.data.ClientDataType.SMALLINT_BYTE_SIZE + 1];
+        Arrays.fill(tooManyBytes, (byte) 5);
         assertDoesNotThrow(() -> ValueConverter.SmallInt.fromBytes(tooFewBytes));
         assertDoesNotThrow(() -> ValueConverter.SmallInt.fromBytes(exactBytes));
         assertThrows(C3rRuntimeException.class, () -> ValueConverter.SmallInt.fromBytes(tooManyBytes));
@@ -211,6 +234,31 @@ public class ValueConverterTest {
         assertEquals("hello", ValueConverter.String.fromBytes(ValueConverter.String.toBytes("hello")));
         assertNull(ValueConverter.String.fromBytes(null));
         assertNull(ValueConverter.String.toBytes(null));
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = Units.Seconds.class)
+    public void timestampByUnitsBytesTest(final Units.Seconds unit) {
+        final BigInteger expected = Units.Seconds.convert(BigInteger.valueOf(Long.MAX_VALUE), unit, Units.Seconds.NANOS);
+        assertEquals(expected, ValueConverter.Timestamp.fromBytes(ValueConverter.Timestamp.toBytes(Long.MAX_VALUE, unit)));
+        assertEquals(expected, ValueConverter.Timestamp.fromBytes(ValueConverter.Timestamp.toBytes(Long.MAX_VALUE, unit)));
+    }
+
+    @Test
+    public void timestampBytesTest() {
+        assertNull(ValueConverter.Timestamp.toBytes(null, Units.Seconds.MILLIS));
+        assertNull(ValueConverter.Timestamp.toBytes(null, Units.Seconds.MILLIS));
+        assertNull(ValueConverter.Timestamp.toBytes(null, null));
+        assertNull(ValueConverter.Timestamp.toBytes(null, null));
+        assertNull(ValueConverter.Timestamp.fromBytes(null));
+    }
+
+    @Test
+    public void varcharBytesTest() {
+        final String expected = "hello  ";
+        assertEquals(expected, ValueConverter.Varchar.fromBytes(ValueConverter.Varchar.toBytes(expected)));
+        assertNull(ValueConverter.Varchar.fromBytes(null));
+        assertNull(ValueConverter.Varchar.toBytes(null));
     }
 
     private static Stream<Arguments> encodeDecodeInputs() {
@@ -295,7 +343,8 @@ public class ValueConverterTest {
         final Function<T, byte[]> encoder = getEncoder(type);
         final Function<byte[], T> decoder = getDecoder(type);
         assertEquals(value, decoder.apply(encoder.apply(value)));
-        assertNull(decoder.apply(encoder.apply(null)));
+        assertEquals(ClientDataInfo.BYTE_LENGTH, encoder.apply(null).length);
+        assertThrows(NullPointerException.class, () -> decoder.apply(null));
         assertArrayEquals(new byte[]{ClientDataInfo.builder().type(type).isNull(true).build().encode()}, encoder.apply(null));
         assertThrows(NullPointerException.class, () -> decoder.apply(null));
         assertThrows(C3rRuntimeException.class, () -> decoder.apply(new byte[0]));
@@ -304,5 +353,194 @@ public class ValueConverterTest {
                 .put((byte) 10)
                 .array();
         assertThrows(C3rRuntimeException.class, () -> decoder.apply(badTypeValue));
+    }
+
+    @Test
+    public void charEncodeDecodeTest() {
+        final char[] value = new char[]{'\0', '\0', 'A', 'B', 'C'};
+
+        assertArrayEquals(value, ValueConverter.Char.decode(ValueConverter.Char.encode(value)));
+
+        assertNull(ValueConverter.Char.decode(ValueConverter.Char.encode(null)));
+
+        assertArrayEquals(
+                new byte[]{ClientDataInfo.builder().type(com.amazonaws.c3r.data.ClientDataType.CHAR).isNull(true).build().encode()},
+                ValueConverter.Char.encode(null));
+
+        assertThrows(NullPointerException.class, () -> ValueConverter.Char.decode(null));
+        assertThrows(C3rRuntimeException.class, () -> ValueConverter.Char.decode(new byte[0]));
+
+        final byte[] badValue = ByteBuffer.allocate(1)
+                .put(ClientDataInfo.builder().type(ClientDataType.UNKNOWN).isNull(true).build().encode())
+                .array();
+        assertThrows(C3rRuntimeException.class, () -> ValueConverter.Char.decode(badValue));
+
+        final byte[] bytes = StandardCharsets.UTF_8.encode(CharBuffer.wrap(value)).array();
+        final byte[] badLength = ByteBuffer.allocate(1 + Integer.BYTES + bytes.length)
+                .put(ClientDataInfo.builder().type(com.amazonaws.c3r.data.ClientDataType.CHAR).isNull(false).build().encode())
+                .putInt(value.length - 1)
+                .put(bytes)
+                .array();
+        assertThrows(C3rRuntimeException.class, () -> ValueConverter.Char.decode(badLength));
+    }
+
+    @Test
+    public void decimalEncodeDecodeTest() {
+        final int scale = 3;
+        final int precision = 4;
+        final BigDecimal value = new BigDecimal(BigInteger.TEN, scale, new MathContext(precision));
+
+        final ClientValueWithMetadata.Decimal decodedInfo = ValueConverter.Decimal.decode(
+                ValueConverter.Decimal.encode(value, precision, scale));
+        assertEquals(value, decodedInfo.getValue());
+        assertEquals(scale, decodedInfo.getValue().scale());
+        assertEquals(scale, decodedInfo.getScale());
+        assertEquals(precision, decodedInfo.getPrecision());
+
+        final ClientValueWithMetadata.Decimal decodedNullInfo = ValueConverter.Decimal.decode(
+                ValueConverter.Decimal.encode(null, null, null));
+        assertNotNull(decodedNullInfo);
+        assertNull(decodedNullInfo.getValue());
+        assertNull(decodedNullInfo.getScale());
+        assertNull(decodedNullInfo.getPrecision());
+
+        final ClientValueWithMetadata.Decimal decodedNullWithMetaInfo = ValueConverter.Decimal.decode(
+                ValueConverter.Decimal.encode(null, precision, scale));
+        assertNotNull(decodedNullWithMetaInfo);
+        assertNull(decodedNullWithMetaInfo.getValue());
+        assertEquals(scale, decodedNullWithMetaInfo.getScale());
+        assertEquals(precision, decodedNullWithMetaInfo.getPrecision());
+
+        assertThrows(C3rIllegalArgumentException.class, () -> ValueConverter.Decimal.decode(
+                ValueConverter.Decimal.encode(value, null, null)));
+        assertThrows(C3rIllegalArgumentException.class, () -> ValueConverter.Decimal.decode(
+                ValueConverter.Decimal.encode(value, precision, null)));
+        assertThrows(C3rIllegalArgumentException.class, () -> ValueConverter.Decimal.decode(
+                ValueConverter.Decimal.encode(value, null, scale)));
+
+        final byte[] badValue = ByteBuffer.allocate(1)
+                .put(ClientDataInfo.builder().type(ClientDataType.UNKNOWN).isNull(true).build().encode())
+                .array();
+        assertThrows(C3rRuntimeException.class, () -> ValueConverter.Decimal.decode(badValue));
+
+        final byte[] bytes = value.toString().getBytes(StandardCharsets.UTF_8);
+        final byte[] badPrecision = ByteBuffer.allocate(ClientDataInfo.BYTE_LENGTH + 2 * Integer.BYTES + bytes.length)
+                .put(ClientDataInfo.builder().type(com.amazonaws.c3r.data.ClientDataType.DECIMAL).isNull(false).build().encode())
+                .putInt(precision - 1)
+                .putInt(scale)
+                .put(bytes)
+                .array();
+        assertThrows(C3rRuntimeException.class, () -> ValueConverter.Decimal.decode(badPrecision));
+
+        final byte[] badScale = ByteBuffer.allocate(ClientDataInfo.BYTE_LENGTH + 2 * Integer.BYTES + bytes.length)
+                .put(ClientDataInfo.builder().type(com.amazonaws.c3r.data.ClientDataType.DECIMAL).isNull(false).build().encode())
+                .putInt(precision)
+                .putInt(scale + 1)
+                .put(bytes)
+                .array();
+        assertThrows(C3rRuntimeException.class, () -> ValueConverter.Decimal.decode(badScale));
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = Units.Seconds.class)
+    public void timestampEncodeDecodeTest(final Units.Seconds unit) {
+        final long value = Long.MIN_VALUE;
+
+        final ClientValueWithMetadata.Timestamp decodedIsUtc = ValueConverter.Timestamp.decode(
+                ValueConverter.Timestamp.encode(value, true, unit));
+        assertEquals(value, decodedIsUtc.getValue());
+        assertTrue(decodedIsUtc.getIsUtc());
+        assertEquals(unit, decodedIsUtc.getUnit());
+
+        final ClientValueWithMetadata.Timestamp decodedNotUtc = ValueConverter.Timestamp.decode(
+                ValueConverter.Timestamp.encode(value, false, unit));
+        assertEquals(value, decodedNotUtc.getValue());
+        assertFalse(decodedNotUtc.getIsUtc());
+        assertEquals(unit, decodedNotUtc.getUnit());
+
+        assertThrows(C3rIllegalArgumentException.class, () -> ValueConverter.Timestamp.encode(value, null, unit));
+        assertThrows(C3rIllegalArgumentException.class, () -> ValueConverter.Timestamp.encode(value, true, null));
+        assertThrows(C3rIllegalArgumentException.class, () -> ValueConverter.Timestamp.encode(value, null, null));
+
+        final ClientValueWithMetadata.Timestamp decodedNull = ValueConverter.Timestamp.decode(
+                ValueConverter.Timestamp.encode(null, null, null));
+        assertNotNull(decodedNull);
+        assertNull(decodedNull.getValue());
+        assertNull(decodedNull.getIsUtc());
+        assertNull(decodedNull.getUnit());
+
+        final ClientValueWithMetadata.Timestamp decodedNullWithMetadata = ValueConverter.Timestamp.decode(
+                ValueConverter.Timestamp.encode(null, true, unit));
+        assertNotNull(decodedNullWithMetadata);
+        assertNull(decodedNullWithMetadata.getValue());
+        assertEquals(true, decodedNullWithMetadata.getIsUtc());
+        assertEquals(unit, decodedNullWithMetadata.getUnit());
+
+        final byte[] badValue = ByteBuffer.allocate(1)
+                .put(ClientDataInfo.builder().type(ClientDataType.UNKNOWN).isNull(true).build().encode())
+                .array();
+        assertThrows(C3rRuntimeException.class, () -> ValueConverter.Timestamp.decode(badValue));
+
+        final byte[] badUtc = ByteBuffer.allocate(ClientDataInfo.BYTE_LENGTH + Byte.BYTES + Integer.BYTES + Long.BYTES)
+                .put(ClientDataInfo.builder().type(com.amazonaws.c3r.data.ClientDataType.TIMESTAMP).isNull(false).build().encode())
+                .put(new byte[]{3})
+                .putInt(unit.ordinal())
+                .putLong(value)
+                .array();
+        assertThrows(C3rRuntimeException.class, () -> ValueConverter.Timestamp.decode(badUtc));
+
+        final byte[] badUnit = ByteBuffer.allocate(ClientDataInfo.BYTE_LENGTH + Byte.BYTES + Integer.BYTES + Long.BYTES)
+                .put(ClientDataInfo.builder().type(com.amazonaws.c3r.data.ClientDataType.TIMESTAMP).isNull(false).build().encode())
+                .put(new byte[]{1})
+                .putInt(Units.Seconds.values().length + 1)
+                .putLong(value)
+                .array();
+        assertThrows(C3rRuntimeException.class, () -> ValueConverter.Timestamp.decode(badUnit));
+    }
+
+    @Test
+    public void varcharEncodeDecodeTest() {
+        final String shorterValue = "hello";
+        final String value = " hello ";
+        final String longerValue = "hello world";
+        final int maxLength = value.length();
+
+        final ClientValueWithMetadata.Varchar shorterResult = ValueConverter.Varchar.decode(
+                ValueConverter.Varchar.encode(shorterValue, maxLength));
+        assertEquals(shorterValue, shorterResult.getValue());
+        assertEquals(maxLength, shorterResult.getMaxLength());
+
+        final ClientValueWithMetadata.Varchar valueResult = ValueConverter.Varchar.decode(ValueConverter.Varchar.encode(value, maxLength));
+        assertEquals(value, valueResult.getValue());
+        assertEquals(maxLength, valueResult.getMaxLength());
+
+        assertThrows(C3rIllegalArgumentException.class, () -> ValueConverter.Varchar.encode(longerValue, maxLength));
+
+        final ClientValueWithMetadata.Varchar nullResult = ValueConverter.Varchar.decode(ValueConverter.Varchar.encode(null, null));
+        assertNotNull(nullResult);
+        assertNull(nullResult.getValue());
+        assertNull(nullResult.getMaxLength());
+
+        assertThrows(C3rRuntimeException.class, () -> ValueConverter.Varchar.encode(value, null));
+
+        final ClientValueWithMetadata.Varchar nullWithMetadataResult = ValueConverter.Varchar.decode(
+                ValueConverter.Varchar.encode(null, maxLength));
+        assertNotNull(nullWithMetadataResult);
+        assertNull(nullWithMetadataResult.getValue());
+        assertEquals(maxLength, nullWithMetadataResult.getMaxLength());
+
+        final byte[] badValue = ByteBuffer.allocate(1)
+                .put(ClientDataInfo.builder().type(ClientDataType.UNKNOWN).isNull(true).build().encode())
+                .array();
+        assertThrows(C3rRuntimeException.class, () -> ValueConverter.Varchar.decode(badValue));
+
+        final byte[] badLength = ByteBuffer.allocate(ClientDataInfo.BYTE_LENGTH + 2 * Integer.BYTES +
+                        longerValue.getBytes(StandardCharsets.UTF_8).length)
+                .put(ClientDataInfo.builder().type(com.amazonaws.c3r.data.ClientDataType.VARCHAR).isNull(false).build().encode())
+                .putInt(maxLength)
+                .putInt(longerValue.length())
+                .put(longerValue.getBytes(StandardCharsets.UTF_8))
+                .array();
+        assertThrows(C3rRuntimeException.class, () -> ValueConverter.Varchar.decode(badLength));
     }
 }


### PR DESCRIPTION
*Description of changes:*
The encoders and decoders that need metadata beyond what is in `ClientDataInfo` (i.e., scale and precision for Decimal)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.