### PR TITLE
fix: Make all encoded string types use utf-8 encoding

### DIFF
--- a/c3r-sdk-core/src/main/java/com/amazonaws/c3r/data/ValueConverter.java
+++ b/c3r-sdk-core/src/main/java/com/amazonaws/c3r/data/ValueConverter.java
@@ -14,7 +14,6 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
-import java.nio.CharBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Objects;
@@ -142,21 +141,19 @@ public final class ValueConverter {
      * Determines how many bytes will be added to the output. If the value is specified, the metadata parameters must all be specified.
      * If the value is null the metadata parameters can either all be specified as null or non-null values but not a mix.
      *
-     * @param value              Value being encoded
-     * @param metadataValues     Array of metadata parameters
-     * @param nonNullValueLength How many bytes will be needed to store metadata for a non-null value
-     * @param nullValueLength    How many bytes will be needed to store metadata when the value is null but the metadata is all non-null
-     * @param <T>                Type of the value being stored
+     * @param value          Value being encoded
+     * @param metadataValues Array of metadata parameters
+     * @param metadataLength How many bytes will be needed to store metadata
+     * @param <T>            The data type for the value
      * @return Number of bytes that will be needed to store metadata.
      */
-    private static <T> int getMetaDataByteLength(final T value, @NonNull final Object[] metadataValues, final int nonNullValueLength,
-                                                 final int nullValueLength) {
+    private static <T> int getMetaDataByteLength(final T value, @NonNull final Object[] metadataValues, final int metadataLength) {
         if (value == null && Arrays.stream(metadataValues).allMatch(Objects::nonNull)) {
-            return nullValueLength;
+            return metadataLength;
         } else if (value == null) {
             return 0;
         }
-        return nonNullValueLength;
+        return metadataLength;
     }
 
     /**
@@ -214,7 +211,7 @@ public final class ValueConverter {
      * @param value  Value being encoded
      * @param type   Client data type being encoded
      * @param size   Expected size of the value in bytes
-     * @param putter Function to call on {@ByteBuffer} to store the value
+     * @param putter Function to call on {@code ByteBuffer} to store the value
      * @param <T>    Java type being converted to bytes
      * @return Byte representation of value
      */
@@ -224,7 +221,41 @@ public final class ValueConverter {
         final int length = (value == null) ? 0 : size;
         final ByteBuffer buffer = ByteBuffer.allocate(ClientDataInfo.BYTE_LENGTH + length)
                 .put(info.encode());
-        return encodeValue(value, buffer, x -> putter.apply(buffer, x));
+        final byte[] bytes = encodeValue(value, buffer, x -> putter.apply(buffer, x));
+        checkBufferHasNoRemaining(buffer);
+        return bytes;
+    }
+
+    /**
+     * Encodes a string based value and its length into a byte array. Length is included to verify correct decoding of the value.
+     *
+     * <p>
+     * For a non-null value, the encoded byte array is of the form:<br/>
+     * Byte 1: {@link ClientDataInfo}<br/>
+     * Bytes 2-5: Length of the String<br/>
+     * Bytes 6+: Bytes for the UTF-8 formatted version of the string
+     * </p>
+     *
+     * <p>
+     * For a null value, the encoded byte array is of the form:<br/>
+     * Byte 1: {@code ClientDataInfo}
+     * </p>
+     *
+     * @param type  The specific C3R string based data type
+     * @param value String value
+     * @return Byte array with all the information to correctly reconstruct the string
+     */
+    private static byte[] encodeString(@NonNull final ClientDataType type, final java.lang.String value) {
+        final ClientDataInfo info = ClientDataInfo.builder().type(type).isNull(value == null).build();
+        final byte[] bytes = stringToBytes(value);
+        final int length = (bytes == null) ? 0 : bytes.length;
+        final ByteBuffer buffer = ByteBuffer.allocate(ClientDataInfo.BYTE_LENGTH + length)
+                .put(info.encode());
+        if (value != null) {
+            buffer.put(bytes);
+        }
+        checkBufferHasNoRemaining(buffer);
+        return buffer.array();
     }
 
     /**
@@ -241,16 +272,41 @@ public final class ValueConverter {
                                      @NonNull final Function<ByteBuffer, T> getter) {
         final ByteBuffer buffer = ByteBuffer.wrap(bytes);
         final ClientDataInfo info = stripClientDataInfo(buffer, type);
-        if (info.isNull()) {
-            return null;
+        T value = null;
+        if (!info.isNull()) {
+            try {
+                value = getter.apply(buffer);
+            } catch (BufferUnderflowException e) {
+                throw new C3rRuntimeException("Value could not be decoded, not enough bytes.", e);
+            }
         }
-        try {
-            final T value = getter.apply(buffer);
-            checkBuffer(buffer);
-            return value;
-        } catch (BufferUnderflowException e) {
-            throw new C3rRuntimeException("Value could not be decoded, not enough bytes.", e);
+        checkBufferHasNoRemaining(buffer);
+        return value;
+    }
+
+    /**
+     * Decodes a byte array into the original string based value. Verifies the string is of the expected length.
+     *
+     * @param type  The specific C3R string based data type
+     * @param bytes Encoded string based value with information needed to recreate the correct value
+     * @return Decoded String value
+     * @throws C3rRuntimeException if not enough bytes are present, the wrong type is found or the length checks fail
+     */
+    private static java.lang.String stringDecode(@NonNull final ClientDataType type, final byte[] bytes) {
+        final ByteBuffer buffer = ByteBuffer.wrap(bytes);
+        final ClientDataInfo info = stripClientDataInfo(buffer, type);
+        java.lang.String value = null;
+        if (!info.isNull()) {
+            try {
+                final byte[] strBytes = new byte[buffer.remaining()];
+                buffer.get(strBytes);
+                value = stringFromBytes(strBytes);
+            } catch (BufferUnderflowException e) {
+                throw new C3rRuntimeException("Value could not be decoded, not enough bytes.", e);
+            }
         }
+        checkBufferHasNoRemaining(buffer);
+        return value;
     }
 
     /**
@@ -259,7 +315,7 @@ public final class ValueConverter {
      * @param value Boolean to turn into bytes
      * @return Byte array of 1 byte that stores a representation of the boolean value
      */
-    private static byte[] getBytesFromBoolean(final boolean value) {
+    private static byte[] booleanToBytes(final boolean value) {
         if (value) {
             return new byte[]{(byte) 1};
         } else {
@@ -274,7 +330,7 @@ public final class ValueConverter {
      * @return The boolean value the byte represents
      * @throws C3rIllegalArgumentException if the byte does not represent a valid boolean value
      */
-    private static boolean getBooleanFromByte(final byte value) {
+    private static boolean booleanFromByte(final byte value) {
         if (value == (byte) 0) {
             return false;
         } else if (value == (byte) 1) {
@@ -290,7 +346,7 @@ public final class ValueConverter {
      * @param buffer {@code ByteBuffer} that should have no remaining bytes to read
      * @throws C3rRuntimeException If there are still bytes left in the array
      */
-    private static void checkBuffer(@NonNull final ByteBuffer buffer) {
+    private static void checkBufferHasNoRemaining(@NonNull final ByteBuffer buffer) {
         if (buffer.hasRemaining()) {
             throw new C3rRuntimeException(buffer.remaining() + " bytes still left but expected number of bytes have been decoded.");
         }
@@ -416,7 +472,7 @@ public final class ValueConverter {
             } else if (bytes.length != 1) {
                 throw new C3rRuntimeException("Boolean value expected to be a single byte.");
             }
-            return getBooleanFromByte(bytes[0]);
+            return booleanFromByte(bytes[0]);
         }
 
         /**
@@ -429,7 +485,7 @@ public final class ValueConverter {
             if (value == null) {
                 return null;
             }
-            return getBytesFromBoolean(value);
+            return booleanToBytes(value);
         }
 
         /**
@@ -453,17 +509,18 @@ public final class ValueConverter {
         public static java.lang.Boolean decode(final byte[] bytes) {
             final ByteBuffer buffer = ByteBuffer.wrap(bytes);
             final ClientDataInfo info = stripClientDataInfo(buffer, ClientDataType.BOOLEAN);
-            if (info.isNull()) {
-                return null;
+            java.lang.Boolean value = null;
+            if (!info.isNull()) {
+                try {
+                    final byte[] remaining = new byte[buffer.remaining()];
+                    buffer.get(remaining);
+                    value = fromBytes(remaining);
+                } catch (BufferUnderflowException e) {
+                    throw new C3rRuntimeException("Value could not be decoded, not enough bytes.", e);
+                }
             }
-            try {
-                final byte[] remaining = new byte[buffer.remaining()];
-                buffer.get(remaining);
-                checkBuffer(buffer);
-                return fromBytes(remaining);
-            } catch (BufferUnderflowException e) {
-                throw new C3rRuntimeException("Value could not be decoded, not enough bytes.", e);
-            }
+            checkBufferHasNoRemaining(buffer);
+            return value;
         }
     }
 
@@ -472,49 +529,34 @@ public final class ValueConverter {
      */
     public static final class Char {
         /**
-         * Number of bytes of metadata needed to reconstruct a fixed length character array correctly.
-         */
-        private static final int TOTAL_METADATA_BYTES = Integer.BYTES;
-
-        /**
          * Converts bytes to a fixed length character array.
          *
          * @param bytes UTF-8 encoded bytes to convert
          * @return Fixed length character array
          */
-        public static char[] fromBytes(final byte[] bytes) {
-            final java.lang.String value = stringFromBytes(bytes);
-            return value == null ? null : value.toCharArray();
+        public static java.lang.String fromBytes(final byte[] bytes) {
+            return stringFromBytes(bytes);
         }
 
         /**
          * Convert a fixed length character array to a byte array.
          *
-         * @param characters Character ta turn into UTF-8 encoded bytes
+         * @param value Character ta turn into UTF-8 encoded bytes
          * @return UTF-8 byte encoding of string
          */
-        public static byte[] toBytes(final char[] characters) {
-            final java.lang.String value = characters == null ? null : new java.lang.String(characters);
+        public static byte[] toBytes(final java.lang.String value) {
             return stringToBytes(value);
         }
 
         /**
          * Encodes a fixed length character array along with necessary metadata to reconstitute the value for encryption.
+         * See {@link ValueConverter#encodeString} for byte format.
          *
          * @param value Character array  to encrypt
          * @return Byte representation of the value and its metadata
          */
-        public static byte[] encode(final char[] value) {
-            final ClientDataInfo info = ClientDataInfo.builder().type(ClientDataType.CHAR).isNull(value == null).build();
-            final byte[] bytes = (value == null) ? null : StandardCharsets.UTF_8.encode(CharBuffer.wrap(value)).array();
-            final int length = (value == null) ? 0 : TOTAL_METADATA_BYTES + bytes.length;
-            final ByteBuffer buffer = ByteBuffer.allocate(ClientDataInfo.BYTE_LENGTH + length)
-                    .put(info.encode());
-            if (value != null) {
-                buffer.putInt(value.length);
-                buffer.put(bytes);
-            }
-            return buffer.array();
+        public static byte[] encode(final java.lang.String value) {
+            return encodeString(ClientDataType.CHAR, value);
         }
 
         /**
@@ -524,24 +566,8 @@ public final class ValueConverter {
          * @return Char value
          * @throws C3rRuntimeException if not enough bytes are in the encoded value or the data type is not Char
          */
-        public static char[] decode(final byte[] bytes) {
-            final ByteBuffer buffer = ByteBuffer.wrap(bytes);
-            final ClientDataInfo info = stripClientDataInfo(buffer, ClientDataType.CHAR);
-            if (info.isNull()) {
-                return null;
-            }
-            try {
-                final int length = buffer.getInt();
-                final char[] value = StandardCharsets.UTF_8.decode(buffer).array();
-                if (value.length != length) {
-                    throw new C3rRuntimeException("Fixed length character array expected to be of length " + length + " but was " +
-                            value.length + ".");
-                }
-                checkBuffer(buffer);
-                return value;
-            } catch (BufferUnderflowException e) {
-                throw new C3rRuntimeException("Value could not be decoded, not enough bytes.", e);
-            }
+        public static java.lang.String decode(final byte[] bytes) {
+            return stringDecode(ClientDataType.CHAR, bytes);
         }
     }
 
@@ -602,6 +628,23 @@ public final class ValueConverter {
         private static final int TOTAL_METADATA_BYTES = 2 * Integer.BYTES;
 
         /**
+         * Checks that the scale and precision on the value are within the bounds of the specified scale and precision.
+         *
+         * @param specifiedPrecision Precision in metadata
+         * @param valuePrecision     Precision of decoded value
+         * @param specifiedScale     Scale in metadata
+         * @param valueScale         Scale of decoded value
+         * @return {@code true} if the decoded scale and precision are within the bounds of the values in the metadata.
+         */
+        private static boolean isValueInvalid(final int specifiedPrecision, final int valuePrecision,
+                                              final int specifiedScale, final int valueScale) {
+            return (specifiedPrecision < valuePrecision) ||
+                    (specifiedScale > 0 && specifiedScale < valueScale) ||
+                    (specifiedScale < 0 && specifiedScale > valueScale) ||
+                    (specifiedScale == 0 && valueScale != 0);
+        }
+
+        /**
          * Takes a byte array and returns the fixed point number it represents. This is done by transforming the byte array into
          * a string and then a {@code BigDecimal} value. Precision and scale may be smaller than they were originally since they
          * are calculated using the digits present in the string value only.
@@ -657,6 +700,7 @@ public final class ValueConverter {
          * @return Byte array encoding all the information to recreate the decimal value
          * @throws C3rIllegalArgumentException if precision and scale are missing for a non-null value
          *                                     or have non-matching null status for a null value
+         * @throws C3rRuntimeException if value is outside the limits imposed by precision and scale
          */
         public static byte[] encode(final BigDecimal value, final Integer precision, final Integer scale) {
             final Object[] metadata = new Object[]{precision, scale};
@@ -665,21 +709,24 @@ public final class ValueConverter {
                         "then they may optionally be null.");
             }
             final ClientDataInfo info = ClientDataInfo.builder().type(ClientDataType.DECIMAL).isNull(value == null).build();
-            final char[] plainString = (value == null) ? null : value.toPlainString().toCharArray();
-            int length = ClientDataInfo.BYTE_LENGTH;
-            length += getMetaDataByteLength(value, metadata, TOTAL_METADATA_BYTES, TOTAL_METADATA_BYTES);
-            length += (value == null) ? 0 : plainString.length * Character.BYTES;
-            final ByteBuffer buffer = ByteBuffer.allocate(length)
+            final byte[] plainString = (value == null) ? null : value.toPlainString().getBytes(StandardCharsets.UTF_8);
+            int length = getMetaDataByteLength(value, metadata, TOTAL_METADATA_BYTES);
+            length += (value == null) ? 0 : plainString.length;
+            final ByteBuffer buffer = ByteBuffer.allocate(ClientDataInfo.BYTE_LENGTH + length)
                     .put(info.encode());
             if (value != null) {
+                if (isValueInvalid(precision, value.precision(), scale, value.scale())) {
+                    throw new C3rRuntimeException("Value is outside of the limits imposed by precision and scale");
+                }
                 buffer.putInt(precision);
                 buffer.putInt(scale);
-                buffer.asCharBuffer().put(plainString);
+                buffer.put(plainString);
                 return buffer.array();
             } else if (precision != null && scale != null) {
                 buffer.putInt(precision);
                 buffer.putInt(scale);
             }
+            checkBufferHasNoRemaining(buffer);
             return buffer.array();
         }
 
@@ -688,7 +735,8 @@ public final class ValueConverter {
          *
          * @param bytes Encoded timestamp with information needed to recreate the correct value
          * @return Information needed to create the value
-         * @throws C3rRuntimeException if not enough bytes are present or the bytes do not represent a {@code BigDecimal} value
+         * @throws C3rRuntimeException if not enough bytes are present, the bytes do not represent a {@code BigDecimal} value
+         *                             or the value is outside the limits imposed by precision and scale
          */
         public static ClientValueWithMetadata.Decimal decode(final byte[] bytes) {
             final ByteBuffer buffer = ByteBuffer.wrap(bytes);
@@ -702,11 +750,15 @@ public final class ValueConverter {
                 }
                 BigDecimal value = null;
                 if (!info.isNull()) {
-                    final java.lang.String stringValue = buffer.asCharBuffer().toString();
-                    buffer.position(buffer.limit());
+                    final byte[] strBytes = new byte[buffer.remaining()];
+                    buffer.get(strBytes);
+                    final java.lang.String stringValue = stringFromBytes(strBytes);
                     value = new BigDecimal(stringValue);
+                    if (isValueInvalid(precision, value.precision(), scale, value.scale())) {
+                        throw new C3rRuntimeException("Value is outside of the limits imposed by precision and scale");
+                    }
                 }
-                checkBuffer(buffer);
+                checkBufferHasNoRemaining(buffer);
                 return new ClientValueWithMetadata.Decimal(value, precision, scale);
             } catch (BufferUnderflowException bue) {
                 throw new C3rRuntimeException("Value could not be decoded, not enough bytes.", bue);
@@ -728,7 +780,7 @@ public final class ValueConverter {
          * @return Corresponding float value
          * @throws C3rRuntimeException If the byte array is not the expected length
          */
-        static java.lang.Double fromBytes(final byte[] bytes) {
+        public static java.lang.Double fromBytes(final byte[] bytes) {
             return basicFromBytes(bytes, java.lang.Double.BYTES, ClientDataType.DOUBLE, ByteBuffer::getDouble);
         }
 
@@ -934,14 +986,13 @@ public final class ValueConverter {
 
         /**
          * Encodes a String value along with necessary metadata to reconstitute the value for encryption.
+         * See {@link ValueConverter#encodeString} for byte format.
          *
          * @param value String value to encrypt
          * @return Byte representation of the value and its metadata
          */
         public static byte[] encode(final java.lang.String value) {
-            final byte[] asBytes = toBytes(value);
-            final int size = asBytes == null ? 0 : asBytes.length;
-            return basicEncode(asBytes, ClientDataType.STRING, size, ByteBuffer::put);
+            return encodeString(ClientDataType.STRING, value);
         }
 
         /**
@@ -952,19 +1003,7 @@ public final class ValueConverter {
          * @throws C3rRuntimeException if not enough bytes are in the encoded value or the data type is not String
          */
         public static java.lang.String decode(final byte[] bytes) {
-            final ByteBuffer buffer = ByteBuffer.wrap(bytes);
-            final ClientDataInfo info = stripClientDataInfo(buffer, ClientDataType.STRING);
-            if (info.isNull()) {
-                return null;
-            }
-            try {
-                final byte[] strBuffer = new byte[bytes.length - ClientDataInfo.BYTE_LENGTH];
-                buffer.get(strBuffer, 0, strBuffer.length);
-                checkBuffer(buffer);
-                return fromBytes(strBuffer);
-            } catch (BufferUnderflowException e) {
-                throw new C3rRuntimeException("Value could not be decoded, not enough bytes.", e);
-            }
+            return stringDecode(ClientDataType.STRING, bytes);
         }
     }
 
@@ -1042,16 +1081,17 @@ public final class ValueConverter {
             }
             final ClientDataInfo info = ClientDataInfo.builder().type(ClientDataType.TIMESTAMP).isNull(value == null).build();
             int length = ClientDataInfo.BYTE_LENGTH;
-            length += getMetaDataByteLength(value, metadata, TOTAL_METADATA_BYTES, TOTAL_METADATA_BYTES);
+            length += getMetaDataByteLength(value, metadata, TOTAL_METADATA_BYTES);
             length += (value == null) ? 0 : Long.BYTES;
             final ByteBuffer buffer = ByteBuffer.allocate(length).put(info.encode());
             if (buffer.remaining() >= TOTAL_METADATA_BYTES) {
-                buffer.put(getBytesFromBoolean(isUtc));
+                buffer.put(booleanToBytes(isUtc));
                 buffer.putInt(unit.ordinal());
             }
             if (!info.isNull()) {
                 buffer.putLong(value);
             }
+            checkBufferHasNoRemaining(buffer);
             return buffer.array();
         }
 
@@ -1069,7 +1109,7 @@ public final class ValueConverter {
                 java.lang.Boolean isUtc = null;
                 Units.Seconds unit = null;
                 if (buffer.remaining() >= TOTAL_METADATA_BYTES) {
-                    isUtc = getBooleanFromByte(buffer.get());
+                    isUtc = booleanFromByte(buffer.get());
                     final int index = buffer.getInt();
                     if (index >= Units.Seconds.values().length) {
                         throw new C3rRuntimeException("Could not decode unit for timestamp.");
@@ -1080,7 +1120,7 @@ public final class ValueConverter {
                 if (!info.isNull()) {
                     value = buffer.getLong();
                 }
-                checkBuffer(buffer);
+                checkBufferHasNoRemaining(buffer);
                 return new ClientValueWithMetadata.Timestamp(value, isUtc, unit);
             } catch (BufferUnderflowException e) {
                 throw new C3rRuntimeException("Value could not be decoded, not enough bytes.", e);
@@ -1093,14 +1133,9 @@ public final class ValueConverter {
      */
     public static final class Varchar {
         /**
-         * How many bytes are needed to store the metadata for a non-null value.
+         * How many bytes are needed to store the metadata.
          */
-        private static final int TOTAL_METADATA_BYTES = 2 * Integer.BYTES;
-
-        /**
-         * How many bytes are needed to store the metadata for a null value.
-         */
-        private static final int TOTAL_NULL_VALUE_METADATA_BYTES = Integer.BYTES;
+        private static final int TOTAL_METADATA_BYTES = Integer.BYTES;
 
         /**
          * Convert the byte array into a UTF-8 variable length character array.
@@ -1154,18 +1189,17 @@ public final class ValueConverter {
                 throw new C3rIllegalArgumentException("Value is greater than allowed maximum length for varchar field.");
             }
             final ClientDataInfo info = ClientDataInfo.builder().type(ClientDataType.VARCHAR).isNull(value == null).build();
-            int length = getMetaDataByteLength(value, metadata, TOTAL_METADATA_BYTES, TOTAL_NULL_VALUE_METADATA_BYTES);
+            int length = getMetaDataByteLength(value, metadata, TOTAL_METADATA_BYTES);
             length += (value == null) ? 0 : value.getBytes(StandardCharsets.UTF_8).length;
             final ByteBuffer buffer = ByteBuffer.allocate(ClientDataInfo.BYTE_LENGTH + length)
                     .put(info.encode());
-            if (value != null) {
-                buffer.putInt(maxLength);
-                final byte[] bytes = value.getBytes(StandardCharsets.UTF_8);
-                buffer.putInt(bytes.length);
-                buffer.put(bytes);
-            } else if (maxLength != null) {
+            if (maxLength != null) {
                 buffer.putInt(maxLength);
             }
+            if (value != null) {
+                buffer.put(value.getBytes(StandardCharsets.UTF_8));
+            }
+            checkBufferHasNoRemaining(buffer);
             return buffer.array();
         }
 
@@ -1182,22 +1216,20 @@ public final class ValueConverter {
             final ClientDataInfo info = stripClientDataInfo(buffer, ClientDataType.VARCHAR);
             try {
                 Integer maxLength = null;
-                if (buffer.remaining() >= TOTAL_NULL_VALUE_METADATA_BYTES) {
+                if (buffer.remaining() >= TOTAL_METADATA_BYTES) {
                     maxLength = buffer.getInt();
                 }
                 java.lang.String value = null;
                 if (!info.isNull()) {
-                    final int length = buffer.getInt();
-                    value = StandardCharsets.UTF_8.decode(buffer).toString();
-                    if (value.length() != length) {
-                        throw new C3rRuntimeException("Variable length character array expected to be of length " + length + " but was " +
-                                value.length() + ".");
-                    } else if (value.length() > maxLength) {
+                    final byte[] strBytes = new byte[buffer.remaining()];
+                    buffer.get(strBytes);
+                    value = stringFromBytes(strBytes);
+                    if (value.length() > maxLength) {
                         throw new C3rRuntimeException("Varchar expected to be " + maxLength + " characters long at most but was " +
                                 value.length() + " characters long.");
                     }
                 }
-                checkBuffer(buffer);
+                checkBufferHasNoRemaining(buffer);
                 return new ClientValueWithMetadata.Varchar(value, maxLength);
             } catch (BufferUnderflowException e) {
                 throw new C3rRuntimeException("Value could not be decoded, not enough bytes.", e);

--- a/c3r-sdk-core/src/test/java/com/amazonaws/c3r/data/ValueConverterTest.java
+++ b/c3r-sdk-core/src/test/java/com/amazonaws/c3r/data/ValueConverterTest.java
@@ -17,13 +17,14 @@ import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentMatchers;
 
+import java.lang.reflect.InvocationTargetException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.math.MathContext;
 import java.nio.ByteBuffer;
-import java.nio.CharBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
@@ -103,14 +104,43 @@ public class ValueConverterTest {
         }
     }
 
+    private static Stream<Arguments> getValueConverterClasses() {
+        return Stream.of(
+                Arguments.of(ValueConverter.BigInt.class, List.of(Integer.class)),
+                Arguments.of(ValueConverter.BigInt.class, List.of(Long.class)),
+                Arguments.of(ValueConverter.Boolean.class, List.of(Boolean.class)),
+                Arguments.of(ValueConverter.Char.class, List.of(String.class)),
+                Arguments.of(ValueConverter.Date.class, List.of(Integer.class)),
+                Arguments.of(ValueConverter.Decimal.class, List.of(BigDecimal.class)),
+                Arguments.of(ValueConverter.Double.class, List.of(java.lang.Double.class)),
+                Arguments.of(ValueConverter.Float.class, List.of(Float.class)),
+                Arguments.of(ValueConverter.Int.class, List.of(Integer.class)),
+                Arguments.of(ValueConverter.SmallInt.class, List.of(Short.class)),
+                Arguments.of(ValueConverter.String.class, List.of(String.class)),
+                Arguments.of(ValueConverter.Timestamp.class, List.of(Long.class, Units.Seconds.class)),
+                Arguments.of(ValueConverter.Varchar.class, List.of(String.class))
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("getValueConverterClasses")
+    public <T> void nullToFromBytesTest(final Class clazz, final List<Class> inputs)
+            throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        if (inputs.size() == 1) {
+            assertNull(clazz.getMethod("toBytes", inputs.get(0)).invoke(null, (Object) null));
+        } else if (inputs.size() == 2) {
+            assertNull(clazz.getMethod("toBytes", inputs.get(0), inputs.get(1)).invoke(null, null, null));
+        } else {
+            assertTrue(inputs.size() < 3);
+        }
+        assertNull(clazz.getMethod("fromBytes", byte[].class).invoke(null, (Object) null));
+    }
+
     @Test
     public void bigIntBytesTest() {
         assertEquals(
                 42,
                 ValueConverter.BigInt.fromBytes(ValueConverter.BigInt.toBytes(42L)));
-        assertNull(ValueConverter.BigInt.fromBytes(null));
-        assertNull(ValueConverter.BigInt.toBytes((Integer) null));
-        assertNull(ValueConverter.BigInt.toBytes((Long) null));
         // BigInt values can only be at most BIGINT_BYTE_LEN in length
         final byte[] tooFewBytes = new byte[ClientDataType.BIGINT_BYTE_SIZE - 1];
         final byte[] exactBytes = new byte[ClientDataType.BIGINT_BYTE_SIZE];
@@ -129,23 +159,17 @@ public class ValueConverterTest {
         assertEquals(
                 false,
                 ValueConverter.Boolean.fromBytes(ValueConverter.Boolean.toBytes(false)));
-        assertNull(ValueConverter.Boolean.toBytes(null));
-        assertNull(ValueConverter.Boolean.fromBytes(null));
     }
 
     @Test
     public void charBytesTest() {
-        final char[] value = new char[]{'A', 'B', 'C'};
-        assertArrayEquals(value, ValueConverter.Char.fromBytes(ValueConverter.Char.toBytes(value)));
-        assertNull(ValueConverter.Char.toBytes(null));
-        assertNull(ValueConverter.Char.fromBytes(null));
+        final java.lang.String value = "ABC";
+        assertEquals(value, ValueConverter.Char.fromBytes(ValueConverter.Char.toBytes(value)));
     }
 
     @Test
     public void dateBytesTest() {
         assertEquals(1000, ValueConverter.Date.fromBytes(ValueConverter.Date.toBytes(1000)));
-        assertNull(ValueConverter.Date.fromBytes(null));
-        assertNull(ValueConverter.Date.toBytes(null));
         // Date values can be only INT_BYTE_LEN long
         final byte[] tooFewBytes = new byte[Integer.BYTES - 1];
         final byte[] exactBytes = new byte[Integer.BYTES];
@@ -158,8 +182,6 @@ public class ValueConverterTest {
     @Test
     public void decimalBytesTest() {
         assertEquals(BigDecimal.TEN, ValueConverter.Decimal.fromBytes(ValueConverter.Decimal.toBytes(BigDecimal.TEN)));
-        assertNull(ValueConverter.Decimal.fromBytes(null));
-        assertNull(ValueConverter.Decimal.toBytes(null));
     }
 
     @Test
@@ -167,8 +189,6 @@ public class ValueConverterTest {
         assertEquals(
                 42.0,
                 ValueConverter.Double.fromBytes(ValueConverter.Double.toBytes(42.0)));
-        assertNull(ValueConverter.Double.fromBytes(null));
-        assertNull(ValueConverter.Double.toBytes(null));
         // Doubles must be exactly Double.BYTES long
         final byte[] tooFewBytes = new byte[Double.BYTES - 1];
         final byte[] exactBytes = new byte[Double.BYTES];
@@ -183,8 +203,6 @@ public class ValueConverterTest {
         assertEquals(
                 (float) 42.0,
                 ValueConverter.Float.fromBytes(ValueConverter.Float.toBytes((float) 42.0)));
-        assertNull(ValueConverter.Float.fromBytes(null));
-        assertNull(ValueConverter.Float.toBytes(null));
         // Floats must be exactly Float.BYTES long
         final byte[] tooFewBytes = new byte[Float.BYTES - 1];
         final byte[] exactBytes = new byte[Float.BYTES];
@@ -199,8 +217,6 @@ public class ValueConverterTest {
         assertEquals(
                 42,
                 ValueConverter.Int.fromBytes(ValueConverter.Int.toBytes(42)));
-        assertNull(ValueConverter.Int.fromBytes(null));
-        assertNull(ValueConverter.Int.toBytes(null));
         // Integer values can be at most INT_BYTES_LONG long
         final byte[] lessBytes = new byte[com.amazonaws.c3r.data.ClientDataType.INT_BYTE_SIZE - 1];
         final byte[] exactBytes = new byte[com.amazonaws.c3r.data.ClientDataType.INT_BYTE_SIZE];
@@ -216,9 +232,6 @@ public class ValueConverterTest {
         assertEquals(
                 (short) 42,
                 ValueConverter.SmallInt.fromBytes(ValueConverter.SmallInt.toBytes((short) 42)));
-        assertNull(ValueConverter.BigInt.fromBytes(null));
-        assertNull(ValueConverter.BigInt.toBytes((Integer) null));
-        assertNull(ValueConverter.BigInt.toBytes((Long) null));
         // SmallInt values can only be at most BIGINT_BYTE_LEN in length
         final byte[] tooFewBytes = new byte[com.amazonaws.c3r.data.ClientDataType.SMALLINT_BYTE_SIZE - 1];
         final byte[] exactBytes = new byte[com.amazonaws.c3r.data.ClientDataType.SMALLINT_BYTE_SIZE];
@@ -232,8 +245,6 @@ public class ValueConverterTest {
     @Test
     public void stringBytesTest() {
         assertEquals("hello", ValueConverter.String.fromBytes(ValueConverter.String.toBytes("hello")));
-        assertNull(ValueConverter.String.fromBytes(null));
-        assertNull(ValueConverter.String.toBytes(null));
     }
 
     @ParameterizedTest
@@ -248,17 +259,12 @@ public class ValueConverterTest {
     public void timestampBytesTest() {
         assertNull(ValueConverter.Timestamp.toBytes(null, Units.Seconds.MILLIS));
         assertNull(ValueConverter.Timestamp.toBytes(null, Units.Seconds.MILLIS));
-        assertNull(ValueConverter.Timestamp.toBytes(null, null));
-        assertNull(ValueConverter.Timestamp.toBytes(null, null));
-        assertNull(ValueConverter.Timestamp.fromBytes(null));
     }
 
     @Test
     public void varcharBytesTest() {
         final String expected = "hello  ";
         assertEquals(expected, ValueConverter.Varchar.fromBytes(ValueConverter.Varchar.toBytes(expected)));
-        assertNull(ValueConverter.Varchar.fromBytes(null));
-        assertNull(ValueConverter.Varchar.toBytes(null));
     }
 
     private static Stream<Arguments> encodeDecodeInputs() {
@@ -283,9 +289,15 @@ public class ValueConverterTest {
             case BOOLEAN:
                 final Function<Boolean, byte[]> encBool = ValueConverter.Boolean::encode;
                 return (Function<T, byte[]>) encBool;
+            case CHAR:
+                final Function<String, byte[]> encChar = ValueConverter.Char::encode;
+                return (Function<T, byte[]>) encChar;
             case DATE:
                 final Function<Integer, byte[]> encDate = ValueConverter.Date::encode;
                 return (Function<T, byte[]>) encDate;
+            case DECIMAL:
+                final Function<BigDecimal, byte[]> encDecimal = x -> ValueConverter.Decimal.encode(x, null, null);
+                return (Function<T, byte[]>) encDecimal;
             case DOUBLE:
                 final Function<Double, byte[]> encDouble = ValueConverter.Double::encode;
                 return (Function<T, byte[]>) encDouble;
@@ -301,6 +313,12 @@ public class ValueConverterTest {
             case STRING:
                 final Function<String, byte[]> encString = ValueConverter.String::encode;
                 return (Function<T, byte[]>) encString;
+            case TIMESTAMP:
+                final Function<Long, byte[]> encTimestamp = x -> ValueConverter.Timestamp.encode(x, null, null);
+                return (Function<T, byte[]>) encTimestamp;
+            case VARCHAR:
+                final Function<String, byte[]> encVarchar = x -> ValueConverter.Varchar.encode(x, null);
+                return (Function<T, byte[]>) encVarchar;
             default:
                 throw new RuntimeException(type + " doesn't match an encode function.");
         }
@@ -314,9 +332,15 @@ public class ValueConverterTest {
             case BOOLEAN:
                 final Function<byte[], Boolean> decBool = ValueConverter.Boolean::decode;
                 return (Function<byte[], T>) decBool;
+            case CHAR:
+                final Function<byte[], String> decChar = ValueConverter.Char::decode;
+                return (Function<byte[], T>) decChar;
             case DATE:
                 final Function<byte[], Integer> decDate = ValueConverter.Date::decode;
                 return (Function<byte[], T>) decDate;
+            case DECIMAL:
+                final Function<byte[], ClientValueWithMetadata.Decimal> decDecimal = ValueConverter.Decimal::decode;
+                return (Function<byte[], T>) decDecimal;
             case DOUBLE:
                 final Function<byte[], Double> decDouble = ValueConverter.Double::decode;
                 return (Function<byte[], T>) decDouble;
@@ -332,6 +356,12 @@ public class ValueConverterTest {
             case STRING:
                 final Function<byte[], String> decString = ValueConverter.String::decode;
                 return (Function<byte[], T>) decString;
+            case TIMESTAMP:
+                final Function<byte[], ClientValueWithMetadata.Timestamp> decTimestamp = ValueConverter.Timestamp::decode;
+                return (Function<byte[], T>) decTimestamp;
+            case VARCHAR:
+                final Function<byte[], ClientValueWithMetadata.Varchar> decVarchar = ValueConverter.Varchar::decode;
+                return (Function<byte[], T>) decVarchar;
             default:
                 throw new RuntimeException(type + " doesn't match an encode function.");
         }
@@ -342,53 +372,54 @@ public class ValueConverterTest {
     public <T> void basicEncodeDecodeTest(final T value, final ClientDataType type) {
         final Function<T, byte[]> encoder = getEncoder(type);
         final Function<byte[], T> decoder = getDecoder(type);
+
         assertEquals(value, decoder.apply(encoder.apply(value)));
-        assertEquals(ClientDataInfo.BYTE_LENGTH, encoder.apply(null).length);
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = ClientDataType.class, names = "UNKNOWN", mode = EnumSource.Mode.EXCLUDE)
+    public <T> void testBadDecodeInputs(final ClientDataType type) {
+        final Function<byte[], T> decoder = getDecoder(type);
+
         assertThrows(NullPointerException.class, () -> decoder.apply(null));
-        assertArrayEquals(new byte[]{ClientDataInfo.builder().type(type).isNull(true).build().encode()}, encoder.apply(null));
-        assertThrows(NullPointerException.class, () -> decoder.apply(null));
+
         assertThrows(C3rRuntimeException.class, () -> decoder.apply(new byte[0]));
-        final byte[] badTypeValue = ByteBuffer.allocate(2)
-                .put(ClientDataInfo.builder().type(ClientDataType.UNKNOWN).isNull(false).build().encode())
-                .put((byte) 10)
+
+        final byte[] badValue = ByteBuffer.allocate(ClientDataInfo.BYTE_LENGTH)
+                .put(ClientDataInfo.builder().type(ClientDataType.UNKNOWN).isNull(true).build().encode())
                 .array();
-        assertThrows(C3rRuntimeException.class, () -> decoder.apply(badTypeValue));
+        assertThrows(C3rRuntimeException.class, () -> decoder.apply(badValue));
+
+        if (type != ClientDataType.CHAR && type != ClientDataType.STRING && type != ClientDataType.VARCHAR) {
+            final byte[] mismatchedNullInfo = ByteBuffer.allocate(ClientDataInfo.BYTE_LENGTH)
+                    .put(ClientDataInfo.builder().type(type).isNull(false).build().encode())
+                    .array();
+            assertThrows(C3rRuntimeException.class, () -> decoder.apply(mismatchedNullInfo));
+        }
+
+        final byte[] extraBytes = new byte[]{ClientDataInfo.builder().type(type).isNull(true).build().encode(), (byte) 1};
+        assertThrows(C3rRuntimeException.class, () -> decoder.apply(extraBytes));
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = ClientDataType.class, names = "UNKNOWN", mode = EnumSource.Mode.EXCLUDE)
+    public <T> void nullEncodeInputTest(final ClientDataType type) {
+        final Function<T, byte[]> encoder = getEncoder(type);
+        final byte[] expectedBytes = new byte[]{ClientDataInfo.builder().type(type).isNull(true).build().encode()};
+        assertArrayEquals(expectedBytes, encoder.apply(null));
     }
 
     @Test
     public void charEncodeDecodeTest() {
-        final char[] value = new char[]{'\0', '\0', 'A', 'B', 'C'};
-
-        assertArrayEquals(value, ValueConverter.Char.decode(ValueConverter.Char.encode(value)));
-
-        assertNull(ValueConverter.Char.decode(ValueConverter.Char.encode(null)));
-
-        assertArrayEquals(
-                new byte[]{ClientDataInfo.builder().type(com.amazonaws.c3r.data.ClientDataType.CHAR).isNull(true).build().encode()},
-                ValueConverter.Char.encode(null));
-
-        assertThrows(NullPointerException.class, () -> ValueConverter.Char.decode(null));
-        assertThrows(C3rRuntimeException.class, () -> ValueConverter.Char.decode(new byte[0]));
-
-        final byte[] badValue = ByteBuffer.allocate(1)
-                .put(ClientDataInfo.builder().type(ClientDataType.UNKNOWN).isNull(true).build().encode())
-                .array();
-        assertThrows(C3rRuntimeException.class, () -> ValueConverter.Char.decode(badValue));
-
-        final byte[] bytes = StandardCharsets.UTF_8.encode(CharBuffer.wrap(value)).array();
-        final byte[] badLength = ByteBuffer.allocate(1 + Integer.BYTES + bytes.length)
-                .put(ClientDataInfo.builder().type(com.amazonaws.c3r.data.ClientDataType.CHAR).isNull(false).build().encode())
-                .putInt(value.length - 1)
-                .put(bytes)
-                .array();
-        assertThrows(C3rRuntimeException.class, () -> ValueConverter.Char.decode(badLength));
+        final java.lang.String value = "\0\0ABC";
+        assertEquals(value, ValueConverter.Char.decode(ValueConverter.Char.encode(value)));
     }
 
     @Test
     public void decimalEncodeDecodeTest() {
         final int scale = 3;
         final int precision = 4;
-        final BigDecimal value = new BigDecimal(BigInteger.TEN, scale, new MathContext(precision));
+        final BigDecimal value = new BigDecimal(1.01, new MathContext(precision)).setScale(scale);
 
         final ClientValueWithMetadata.Decimal decodedInfo = ValueConverter.Decimal.decode(
                 ValueConverter.Decimal.encode(value, precision, scale));
@@ -396,13 +427,6 @@ public class ValueConverterTest {
         assertEquals(scale, decodedInfo.getValue().scale());
         assertEquals(scale, decodedInfo.getScale());
         assertEquals(precision, decodedInfo.getPrecision());
-
-        final ClientValueWithMetadata.Decimal decodedNullInfo = ValueConverter.Decimal.decode(
-                ValueConverter.Decimal.encode(null, null, null));
-        assertNotNull(decodedNullInfo);
-        assertNull(decodedNullInfo.getValue());
-        assertNull(decodedNullInfo.getScale());
-        assertNull(decodedNullInfo.getPrecision());
 
         final ClientValueWithMetadata.Decimal decodedNullWithMetaInfo = ValueConverter.Decimal.decode(
                 ValueConverter.Decimal.encode(null, precision, scale));
@@ -418,24 +442,22 @@ public class ValueConverterTest {
         assertThrows(C3rIllegalArgumentException.class, () -> ValueConverter.Decimal.decode(
                 ValueConverter.Decimal.encode(value, null, scale)));
 
-        final byte[] badValue = ByteBuffer.allocate(1)
-                .put(ClientDataInfo.builder().type(ClientDataType.UNKNOWN).isNull(true).build().encode())
-                .array();
-        assertThrows(C3rRuntimeException.class, () -> ValueConverter.Decimal.decode(badValue));
+        assertThrows(C3rRuntimeException.class, () -> ValueConverter.Decimal.encode(value, 0, scale));
 
         final byte[] bytes = value.toString().getBytes(StandardCharsets.UTF_8);
         final byte[] badPrecision = ByteBuffer.allocate(ClientDataInfo.BYTE_LENGTH + 2 * Integer.BYTES + bytes.length)
                 .put(ClientDataInfo.builder().type(com.amazonaws.c3r.data.ClientDataType.DECIMAL).isNull(false).build().encode())
-                .putInt(precision - 1)
+                .putInt(0)
                 .putInt(scale)
                 .put(bytes)
                 .array();
         assertThrows(C3rRuntimeException.class, () -> ValueConverter.Decimal.decode(badPrecision));
 
+        assertThrows(C3rRuntimeException.class, () -> ValueConverter.Decimal.encode(value, precision, 0));
         final byte[] badScale = ByteBuffer.allocate(ClientDataInfo.BYTE_LENGTH + 2 * Integer.BYTES + bytes.length)
                 .put(ClientDataInfo.builder().type(com.amazonaws.c3r.data.ClientDataType.DECIMAL).isNull(false).build().encode())
                 .putInt(precision)
-                .putInt(scale + 1)
+                .putInt(0)
                 .put(bytes)
                 .array();
         assertThrows(C3rRuntimeException.class, () -> ValueConverter.Decimal.decode(badScale));
@@ -462,24 +484,12 @@ public class ValueConverterTest {
         assertThrows(C3rIllegalArgumentException.class, () -> ValueConverter.Timestamp.encode(value, true, null));
         assertThrows(C3rIllegalArgumentException.class, () -> ValueConverter.Timestamp.encode(value, null, null));
 
-        final ClientValueWithMetadata.Timestamp decodedNull = ValueConverter.Timestamp.decode(
-                ValueConverter.Timestamp.encode(null, null, null));
-        assertNotNull(decodedNull);
-        assertNull(decodedNull.getValue());
-        assertNull(decodedNull.getIsUtc());
-        assertNull(decodedNull.getUnit());
-
         final ClientValueWithMetadata.Timestamp decodedNullWithMetadata = ValueConverter.Timestamp.decode(
                 ValueConverter.Timestamp.encode(null, true, unit));
         assertNotNull(decodedNullWithMetadata);
         assertNull(decodedNullWithMetadata.getValue());
         assertEquals(true, decodedNullWithMetadata.getIsUtc());
         assertEquals(unit, decodedNullWithMetadata.getUnit());
-
-        final byte[] badValue = ByteBuffer.allocate(1)
-                .put(ClientDataInfo.builder().type(ClientDataType.UNKNOWN).isNull(true).build().encode())
-                .array();
-        assertThrows(C3rRuntimeException.class, () -> ValueConverter.Timestamp.decode(badValue));
 
         final byte[] badUtc = ByteBuffer.allocate(ClientDataInfo.BYTE_LENGTH + Byte.BYTES + Integer.BYTES + Long.BYTES)
                 .put(ClientDataInfo.builder().type(com.amazonaws.c3r.data.ClientDataType.TIMESTAMP).isNull(false).build().encode())
@@ -516,11 +526,6 @@ public class ValueConverterTest {
 
         assertThrows(C3rIllegalArgumentException.class, () -> ValueConverter.Varchar.encode(longerValue, maxLength));
 
-        final ClientValueWithMetadata.Varchar nullResult = ValueConverter.Varchar.decode(ValueConverter.Varchar.encode(null, null));
-        assertNotNull(nullResult);
-        assertNull(nullResult.getValue());
-        assertNull(nullResult.getMaxLength());
-
         assertThrows(C3rRuntimeException.class, () -> ValueConverter.Varchar.encode(value, null));
 
         final ClientValueWithMetadata.Varchar nullWithMetadataResult = ValueConverter.Varchar.decode(
@@ -528,11 +533,6 @@ public class ValueConverterTest {
         assertNotNull(nullWithMetadataResult);
         assertNull(nullWithMetadataResult.getValue());
         assertEquals(maxLength, nullWithMetadataResult.getMaxLength());
-
-        final byte[] badValue = ByteBuffer.allocate(1)
-                .put(ClientDataInfo.builder().type(ClientDataType.UNKNOWN).isNull(true).build().encode())
-                .array();
-        assertThrows(C3rRuntimeException.class, () -> ValueConverter.Varchar.decode(badValue));
 
         final byte[] badLength = ByteBuffer.allocate(ClientDataInfo.BYTE_LENGTH + 2 * Integer.BYTES +
                         longerValue.getBytes(StandardCharsets.UTF_8).length)
@@ -542,5 +542,21 @@ public class ValueConverterTest {
                 .put(longerValue.getBytes(StandardCharsets.UTF_8))
                 .array();
         assertThrows(C3rRuntimeException.class, () -> ValueConverter.Varchar.decode(badLength));
+    }
+
+    @Test
+    public void nullVersusEmptyStringTypesTest() {
+        final String empty = "";
+        final ClientValueWithMetadata.Varchar nullMetadata = new ClientValueWithMetadata.Varchar(null, 10);
+        final ClientValueWithMetadata.Varchar emptyMetadata = new ClientValueWithMetadata.Varchar(empty, 10);
+
+        assertNull(ValueConverter.Char.decode(ValueConverter.Char.encode(null)));
+        assertEquals(empty, ValueConverter.Char.decode(ValueConverter.Char.encode(empty)));
+
+        assertNull(ValueConverter.String.decode(ValueConverter.String.encode(null)));
+        assertEquals(empty, ValueConverter.String.decode(ValueConverter.String.encode(empty)));
+
+        assertEquals(nullMetadata, ValueConverter.Varchar.decode(ValueConverter.Varchar.encode(null, emptyMetadata.getMaxLength())));
+        assertEquals(emptyMetadata, ValueConverter.Varchar.decode(ValueConverter.Varchar.encode(empty, emptyMetadata.getMaxLength())));
     }
 }


### PR DESCRIPTION
*Description of changes:*
Change `char[]` to `String` so UTF-8 is used for character based values (makes `CHAR`, `STRING` and `VARCHAR` a valid equivalence class too that way). Also some minor cleanup of code and tests so common functionality is pulled into some common parametrised tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.