### PR TITLE
test: revert "ci: pin spark integration tests to 3.4.1, not latest release (#357)"

### DIFF
--- a/c3r-cli-spark/src/integration-test/spark_integration_tests.py
+++ b/c3r-cli-spark/src/integration-test/spark_integration_tests.py
@@ -33,8 +33,7 @@ def latest_spark_version() -> str:
     versions.sort()
     return '.'.join(versions[-1])
 
-# spark_version=latest_spark_version()
-spark_version="3.4.1"
+spark_version=latest_spark_version()
 spark_dir:str = f'spark-{spark_version}-bin-hadoop3-scala2.13'
 """Apache Spark directory."""
 spark_tgz:str = f'{spark_dir}.tgz'


### PR DESCRIPTION
This reverts commit 106f49bceba56b4eed5941744cab9e92363bd544.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.