### PR TITLE
chore: lock spark version in spark integ tests to version 3.5.1.

### DIFF
--- a/c3r-cli-spark/src/integration-test/spark_integration_tests.py
+++ b/c3r-cli-spark/src/integration-test/spark_integration_tests.py
@@ -15,6 +15,7 @@ from typing import Literal
 # without needing reoccuring `..` in the path.
 repo_dir=Path(os.path.dirname(__file__)).parent.parent.parent.absolute()
 
+# Currently disabled as the newer version of Spark is in preview. Locking to version 3.5.1 for the time being
 def latest_spark_version() -> str:
     """
     Use the Maven Central Repository REST API to get the latest version of the spark-core_2.13 package.
@@ -33,7 +34,7 @@ def latest_spark_version() -> str:
     versions.sort()
     return '.'.join(versions[-1])
 
-spark_version=latest_spark_version()
+spark_version="3.5.1"
 spark_dir:str = f'spark-{spark_version}-bin-hadoop3-scala2.13'
 """Apache Spark directory."""
 spark_tgz:str = f'{spark_dir}.tgz'


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Locks the version of Spark used for integration tests to 3.5.1. Version 4 is currently in preview and has not yet been evaluated.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.