### PR TITLE
docs: Add a FAQ about using FIPS with C3R.

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,8 +223,10 @@ The equivalence classes are:
 - `STRING` containing data types: `CHAR`, `STRING`, `VARCHAR`
 
 ### Does the C3R encryption client implement any non-standard cryptography?
-
 The C3R encryption client uses only NIST-standardized algorithms and-- with one exception-- only by calling their implementation in the Java standard cryptographic library. The sole exception is that the client has its own implementation of HKDF (from RFC5869), but using MAC algorithms from the Java standard cryptographic library.
+
+### Does the C3R encryption client support FIPS?
+Yes, the C3R encryption client supports FIPS endpoints. For more information, see the AWS documentation on [Dual-stack and FIPS endpoints](https://docs.aws.amazon.com/sdkref/latest/guide/feature-endpoints.html).
 
 ## License
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Adds a FAQ pointing to how customers may configure C3R to use FIPS endpoints when communicating with AWS.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.