### PR TITLE
build: Bump CodeBuild Spark version and fix script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ out/
 **/*.out.crc
 **/*.out.unknown
 build/
+bin/

--- a/c3r-cli-spark/src/integration-test/spark_integration_tests.py
+++ b/c3r-cli-spark/src/integration-test/spark_integration_tests.py
@@ -12,7 +12,7 @@ from typing import Literal
 
 # Directory at the top of the git repository, from which we can
 # easily grab any desired files directly from the `samples` dir
-# without needing reoccuring `..` in the path.
+# without needing recurring `..` in the path.
 repo_dir=Path(os.path.dirname(__file__)).parent.parent.parent.absolute()
 
 # Currently disabled as the newer version of Spark is in preview. Locking to version 3.5.1 for the time being
@@ -34,7 +34,7 @@ def latest_spark_version() -> str:
     versions.sort()
     return '.'.join(versions[-1])
 
-spark_version="3.5.1"
+spark_version="3.5.3"
 spark_dir:str = f'spark-{spark_version}-bin-hadoop3-scala2.13'
 """Apache Spark directory."""
 spark_tgz:str = f'{spark_dir}.tgz'

--- a/codebuild/build-and-test-release-artifacts.sh
+++ b/codebuild/build-and-test-release-artifacts.sh
@@ -34,7 +34,7 @@ C3R_CLI_SPARK_DIR=c3r-cli-spark/build/libs
 ./gradlew build -x checkFileUtilTest --parallel
 
 # Get the version from the CLI
-C3R_VERSION=$(java -jar $C3R_CLI_DIR/c3r-cli-all.jar --version)
+C3R_VERSION=$(java -jar $C3R_CLI_DIR/c3r-cli-all.jar --version | tail -1)
 echo "JAR version found: $C3R_VERSION"
 
 # Test CLI JAR


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Bumps Hadoop from 3.5.1 to 3.5.3 for CodeBuild runs.
- Fixes CodeBuild script grabbing logs along with the version of C3R when Log4j is noisy.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.