### PR TITLE
docs: fix 'compatability' typo in Javadoc comments

### DIFF
--- a/c3r-sdk-core/src/main/java/com/amazonaws/c3r/CleartextTransformer.java
+++ b/c3r-sdk-core/src/main/java/com/amazonaws/c3r/CleartextTransformer.java
@@ -16,7 +16,7 @@ import java.nio.charset.StandardCharsets;
  */
 public class CleartextTransformer extends Transformer {
     /**
-     * The version of the {@code CleartextTransformer} for compatability support.
+     * The version of the {@code CleartextTransformer} for compatibility support.
      */
     private static final byte[] FORMAT_VERSION = "01:".getBytes(StandardCharsets.UTF_8);
 

--- a/c3r-sdk-core/src/main/java/com/amazonaws/c3r/FingerprintTransformer.java
+++ b/c3r-sdk-core/src/main/java/com/amazonaws/c3r/FingerprintTransformer.java
@@ -46,7 +46,7 @@ public class FingerprintTransformer extends Transformer {
     private static final byte[] ENCRYPTION_DESCRIPTOR = "hmac:".getBytes(StandardCharsets.UTF_8);
 
     /**
-     * The version of the {@code FingerprintTransformer} for compatability support.
+     * The version of the {@code FingerprintTransformer} for compatibility support.
      */
     private static final byte[] FORMAT_VERSION = "02:".getBytes(StandardCharsets.UTF_8);
 

--- a/c3r-sdk-core/src/main/java/com/amazonaws/c3r/SealedTransformer.java
+++ b/c3r-sdk-core/src/main/java/com/amazonaws/c3r/SealedTransformer.java
@@ -28,7 +28,7 @@ import java.util.Base64;
  */
 public class SealedTransformer extends Transformer {
     /**
-     * The version of the {@code SealedTransformer} for compatability support.
+     * The version of the {@code SealedTransformer} for compatibility support.
      */
     static final byte[] FORMAT_VERSION = "02:".getBytes(StandardCharsets.UTF_8);
 

--- a/c3r-sdk-parquet/src/main/java/com/amazonaws/c3r/data/ParquetDataType.java
+++ b/c3r-sdk-parquet/src/main/java/com/amazonaws/c3r/data/ParquetDataType.java
@@ -67,7 +67,7 @@ public final class ParquetDataType implements Validatable {
     }
 
     /**
-     * Convert a Parquet schema type to a C3R Parquet data type after verifying compatability.
+     * Convert a Parquet schema type to a C3R Parquet data type after verifying compatibility.
      *
      * @param type Parquet type associated with a column
      * @return Instance of the associated {@code ParquetDataTy[e}


### PR DESCRIPTION
## Summary

This PR fixes a repeated typo in Javadoc comments across the codebase where "compatibility" was misspelled as "compatability".

## Changes

| File | Line | Description |
|------|------|-------------|
| `c3r-sdk-parquet/src/main/java/com/amazonaws/c3r/data/ParquetDataType.java` | 70 | Fixed typo in `fromType()` method Javadoc |
| `c3r-sdk-core/src/main/java/com/amazonaws/c3r/CleartextTransformer.java` | 19 | Fixed typo in `FORMAT_VERSION` field Javadoc |
| `c3r-sdk-core/src/main/java/com/amazonaws/c3r/FingerprintTransformer.java` | 49 | Fixed typo in `FORMAT_VERSION` field Javadoc |
| `c3r-sdk-core/src/main/java/com/amazonaws/c3r/SealedTransformer.java` | 31 | Fixed typo in `FORMAT_VERSION` field Javadoc |

## Details

All instances changed: `compatability` → `compatibility`

This is a documentation-only change with no functional impact.